### PR TITLE
Adds a reset function to the pending cursor operation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittolive/react-ditto",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React wrappers for Ditto",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -174,4 +174,77 @@ describe('usePendingCursorOperation tests', function () {
       ).to.eq(true)
     }
   })
+
+  it('should correctly reset the current live query and create a new one when the reset function is called.', async () => {
+    const testConfiguration = testIdentity()
+    const initOptions = {
+      webAssemblyModule: '/base/node_modules/@dittolive/ditto/web/ditto.wasm',
+    }
+
+    const TestComponent: React.FC = () => {
+      const { ditto, insert } = useMutations<unknown>({
+        path: testConfiguration.path,
+        collection: 'foo',
+      })
+
+      useEffect(() => {
+        if (ditto) {
+          insert({ value: { document: 1 } })
+          insert({ value: { document: 2 } })
+          insert({ value: { document: 3 } })
+          insert({ value: { document: 4 } })
+          insert({ value: { document: 5 } })
+        }
+      }, [ditto])
+
+      return <></>
+    }
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DittoProvider
+        setup={() => {
+          const ditto = new Ditto(
+            testConfiguration.identity,
+            testConfiguration.path,
+          )
+          return ditto
+        }}
+        initOptions={initOptions}
+      >
+        {() => {
+          return (
+            <>
+              <TestComponent />
+              {children}
+            </>
+          )
+        }}
+      </DittoProvider>
+    )
+
+    const params: LiveQueryParams = {
+      path: testConfiguration.path,
+      collection: 'foo',
+      query: 'document > 3',
+    }
+    const { result, waitFor } = renderHook(
+      () => usePendingCursorOperation(params),
+      {
+        wrapper,
+      },
+    )
+    await waitFor(() => !!result.current.documents?.length, { timeout: 5000 })
+
+    expect(result.current.documents.length).to.eq(2)
+
+    const liveQueryBeforeReset = result.current.liveQuery
+
+    result.current.reset()
+
+    await waitFor(() => result.current.liveQuery !== liveQueryBeforeReset, {
+      timeout: 5000,
+    })
+
+    expect(result.current.documents.length).to.eq(2)
+  })
 })


### PR DESCRIPTION
We need developers to be able to reset live queries on the pending cursor operation hook. 

An example where this is useful is for example when you have a live query with a `limit`, eg: 

```ts
  const { documents } = usePendingCursorOperation({ collection: 'foo', limit: 1 })
  const hasDocuments = !!documents.length
```

In this case if the document returned by the live query is deleted, the Ditto SDK will not return null and instead simply return an empty an empty array of documents, which can lead to the misinterpretation of the collection being empty. 

The only way to refresh the `documents` result such that the query is relaunched, and a different document from the store can be used as a sentinel of documents existing in the store, is by resetting the current live query.