### PR TITLE
Fixes the loading state on the eager Ditto Provider.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function (config) {
     browsers: ['ChromeHeadless'],
     autoWatch: false,
     // singleRun: false, // Karma captures browsers, runs the tests and exits
-    concurrency: 1,
+    concurrency: Infinity,
     singleRun: true,
     mime: {
       'application/wasm': ['wasm'],
@@ -47,6 +47,9 @@ module.exports = function (config) {
     parallelOptions: {
       executors: 8, // Defaults to cpu-count - 1
       shardStrategy: 'round-robin',
+    },
+    client: {
+      captureConsole: true,
     },
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittolive/react-ditto",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React wrappers for Ditto",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/DittoLazyProvider.spec.tsx
+++ b/src/DittoLazyProvider.spec.tsx
@@ -2,7 +2,6 @@ import { Ditto, IdentityOfflinePlayground } from '@dittolive/ditto'
 import { expect } from 'chai'
 import React, { useContext } from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
-import { act } from 'react-dom/test-utils'
 import { v4 as uuidv4 } from 'uuid'
 
 import { DittoContext } from './DittoContext'

--- a/src/DittoLazyProvider.tsx
+++ b/src/DittoLazyProvider.tsx
@@ -55,6 +55,7 @@ export const DittoLazyProvider: React.FunctionComponent<DittoLazyProviderProps> 
           })
         }
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const renderFunction: RenderFunction | undefined = render || children

--- a/src/DittoProvider.tsx
+++ b/src/DittoProvider.tsx
@@ -61,10 +61,6 @@ export const DittoProvider: React.FunctionComponent<DittoProviderProps> = (
           for (const ditto of dittos) {
             dittoHash[ditto.path] = ditto
           }
-          setProviderState({
-            error: undefined,
-            loading: false,
-          })
           setDittoHash(dittoHash)
         } else {
           const ditto = setupReturnValue as Ditto
@@ -72,6 +68,10 @@ export const DittoProvider: React.FunctionComponent<DittoProviderProps> = (
           dittoHash[ditto.path] = ditto
           setDittoHash(dittoHash)
         }
+        setProviderState({
+          error: undefined,
+          loading: false,
+        })
       } catch (err) {
         setProviderState({
           error: err,

--- a/src/DittoProvider.tsx
+++ b/src/DittoProvider.tsx
@@ -80,6 +80,7 @@ export const DittoProvider: React.FunctionComponent<DittoProviderProps> = (
         setDittoHash({})
       }
     })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const renderFunction: RenderFunction | undefined =

--- a/src/mutations/useMutations.spec.tsx
+++ b/src/mutations/useMutations.spec.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Ditto, IdentityOfflinePlayground } from '@dittolive/ditto'
 import { renderHook } from '@testing-library/react-hooks/dom'
 import { expect } from 'chai'

--- a/src/queries/useCollections.spec.tsx
+++ b/src/queries/useCollections.spec.tsx
@@ -51,7 +51,7 @@ describe('useCollections tests', function () {
         if (ditto) {
           insert({ value: { document: 1 } })
         }
-      }, [ditto])
+      }, [ditto, insert])
 
       return <></>
     }

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -58,7 +58,7 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto])
+      }, [ditto, insert])
 
       return <></>
     }
@@ -126,7 +126,7 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto])
+      }, [ditto, insert])
 
       return <></>
     }
@@ -195,7 +195,7 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto])
+      }, [ditto, insert])
 
       return <></>
     }

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -58,7 +58,8 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto, insert])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [ditto])
 
       return <></>
     }
@@ -126,7 +127,8 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto, insert])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [ditto])
 
       return <></>
     }
@@ -195,7 +197,8 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto, insert])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [ditto])
 
       return <></>
     }

--- a/src/queries/usePendingCursorOperation.tsx
+++ b/src/queries/usePendingCursorOperation.tsx
@@ -156,6 +156,7 @@ export function usePendingCursorOperation<T = Document>(
       liveQueryRef.current?.stop()
       liveQueryRef.current = null
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ditto, params])
 
   return {

--- a/src/queries/usePendingIDSpecificOperation.spec.tsx
+++ b/src/queries/usePendingIDSpecificOperation.spec.tsx
@@ -63,7 +63,7 @@ describe('usePendingCursorOperation tests', function () {
           insert({ value: { document: 4 } })
           insert({ value: { document: 5 } })
         }
-      }, [ditto])
+      }, [ditto, insert])
 
       return <></>
     }

--- a/src/queries/usePendingIDSpecificOperation.tsx
+++ b/src/queries/usePendingIDSpecificOperation.tsx
@@ -55,6 +55,7 @@ export function usePendingIDSpecificOperation<T = Document>(
       liveQuery?.stop()
     }
     /** We need to serialize the _id in order for React's dependency array comparison to work. */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.path, params.collection, params._id?.toString() || '', ditto])
 
   return {

--- a/src/useDitto.ts
+++ b/src/useDitto.ts
@@ -32,6 +32,7 @@ export const useDitto = (path: string | null | undefined): DittoHookProps => {
     if (isLazy) {
       lazyLoadDitto()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ditto, isLazy, path])
 
   return { loading, error, ditto }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,13 @@
+export const waitFor = (cb: () => boolean): Promise<void> => {
+  return new Promise((resolve) => {
+    const interval = setInterval(() => {
+      const result = cb()
+
+      if (result) {
+        clearInterval(interval)
+
+        resolve()
+      }
+    }, 300)
+  })
+}


### PR DESCRIPTION
Fixes a bug on the tests by adding a custom built waitFor function for DOM assertions. The old version was not waiting for the React components to stabilize and this was leading to flaky tests.