### PR TITLE
Problem: cursor hooks should return `DocumentLike` not `Document`

### DIFF
--- a/src/mutations/useMutations.ts
+++ b/src/mutations/useMutations.ts
@@ -1,7 +1,7 @@
 import {
   Ditto,
-  Document,
   DocumentID,
+  DocumentLike,
   DocumentValue,
   InsertOptions,
   PendingCursorOperation,
@@ -79,7 +79,7 @@ export interface UseMutationParams {
   collection: string
 }
 
-export function useMutations<T = Document>(
+export function useMutations<T = DocumentLike>(
   useMutationParams: UseMutationParams,
 ): {
   ditto: Ditto

--- a/src/queries/useLazyPendingCursorOperation.ts
+++ b/src/queries/useLazyPendingCursorOperation.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Ditto,
-  Document,
+  DocumentLike,
   LiveQuery,
   LiveQueryEvent,
   PendingCursorOperation,
@@ -50,7 +50,7 @@ export interface LazyPendingCursorOperationReturn<T> {
  * @returns LazyPendingCursorOperationReturn
  */
 export function useLazyPendingCursorOperation<
-  T = Document,
+  T = DocumentLike,
 >(): LazyPendingCursorOperationReturn<T> {
   const { dittoHash, isLazy, load } = useContext(DittoContext)
   const [documents, setDocuments] = useState<T[]>([])

--- a/src/queries/useLazyPendingIDSpecificOperation.ts
+++ b/src/queries/useLazyPendingIDSpecificOperation.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Ditto,
-  Document,
+  DocumentLike,
   LiveQuery,
   SingleDocumentLiveQueryEvent,
 } from '@dittolive/ditto'
@@ -46,7 +46,7 @@ export interface LazyPendingIDSpecificOperationReturn<T> {
  * @returns LazyPendingIDSpecificOperationReturn
  */
 export function useLazyPendingIDSpecificOperation<
-  T = Document,
+  T = DocumentLike,
 >(): LazyPendingIDSpecificOperationReturn<T> {
   const { dittoHash, isLazy, load } = useContext(DittoContext)
   const liveQueryRef = useRef<LiveQuery>()

--- a/src/queries/usePendingCursorOperation.ts
+++ b/src/queries/usePendingCursorOperation.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Ditto,
-  Document,
+  DocumentLike,
   LiveQuery,
   LiveQueryEvent,
   PendingCursorOperation,
@@ -102,7 +102,7 @@ export interface PendingCursorOperationReturn<T> {
  * @param params live query parameters.
  * @returns
  */
-export function usePendingCursorOperation<T = Document>(
+export function usePendingCursorOperation<T = DocumentLike>(
   params: LiveQueryParams,
 ): PendingCursorOperationReturn<T> {
   const { ditto } = useDitto(params.path)

--- a/src/queries/usePendingIDSpecificOperation.ts
+++ b/src/queries/usePendingIDSpecificOperation.ts
@@ -1,8 +1,8 @@
 import {
   Collection,
   Ditto,
-  Document,
   DocumentID,
+  DocumentLike,
   LiveQuery,
   SingleDocumentLiveQueryEvent,
 } from '@dittolive/ditto'
@@ -53,7 +53,7 @@ export interface PendingIDSpecificOperationReturn<T> {
  * @param params live query parameters.
  * @returns PendingIDSpecificOperationReturn
  */
-export function usePendingIDSpecificOperation<T = Document>(
+export function usePendingIDSpecificOperation<T = DocumentLike>(
   params: UsePendingIDSpecificOperationParams,
 ): PendingIDSpecificOperationReturn<T> {
   const liveQueryRef = useRef<LiveQuery>()


### PR DESCRIPTION
# Problem

@konstantinbe said that we should be returning `DocumentLike` from the `usePendingCursorOperation`  and `usePendingIDSpecificOperations`

