### PR TITLE
Hooks for queries and cursors are missing a "local" param

### DIFF
--- a/src/queries/useLazyPendingCursorOperation.spec.tsx
+++ b/src/queries/useLazyPendingCursorOperation.spec.tsx
@@ -127,6 +127,36 @@ describe('useLazyPendingCursorOperation tests', function () {
     }
   })
 
+  it('should load all documents correctly observing only for local data', async () => {
+    const testConfiguration = testIdentity()
+
+    const params: LiveQueryParams = {
+      path: testConfiguration.path,
+      collection: 'foo',
+      localOnly: true,
+    }
+    const { result, waitFor, waitForNextUpdate } = renderHook(
+      () => useLazyPendingCursorOperation(),
+      {
+        wrapper: wrapper(testConfiguration.identity, testConfiguration.path),
+      },
+    )
+
+    // we wait for the Ditto instance to load.
+    await waitForNextUpdate()
+    await result.current.exec(params)
+
+    await waitFor(() => !!result.current.documents?.length, { timeout: 5000 })
+
+    expect(result.current.documents.length).to.eq(5)
+
+    for (let i = 1; i < 6; i++) {
+      expect(
+        !!result.current.documents.find((doc) => doc._value.document === i),
+      ).to.eq(true)
+    }
+  })
+
   it('should load documents correctly using a query', async () => {
     const testConfiguration = testIdentity()
 

--- a/src/queries/useLazyPendingCursorOperation.ts
+++ b/src/queries/useLazyPendingCursorOperation.ts
@@ -89,10 +89,18 @@ export function useLazyPendingCursorOperation<
       if (params.offset) {
         cursor = cursor.offset(params.offset)
       }
-      liveQueryRef.current = cursor.observe((docs, event) => {
-        setDocuments(docs)
-        setLiveQueryEvent(event)
-      })
+
+      if (params.localOnly) {
+        liveQueryRef.current = cursor.observeLocal((docs, event) => {
+          setDocuments(docs)
+          setLiveQueryEvent(event)
+        })
+      } else {
+        liveQueryRef.current = cursor.observe((docs, event) => {
+          setDocuments(docs)
+          setLiveQueryEvent(event)
+        })
+      }
 
       setCollection(nextCollection)
       setDitto(nextDitto)

--- a/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
+++ b/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
@@ -122,6 +122,35 @@ describe('useLazyPendingIDSpecificOperation tests', function () {
     expect(result.current.event).not.to.eq(undefined)
   })
 
+  it('should load a document by ID correctly when the exec function is called, observing only the local store', async () => {
+    const testConfiguration = testIdentity()
+
+    const params: UsePendingIDSpecificOperationParams = {
+      path: testConfiguration.path,
+      collection: 'foo',
+      _id: new DocumentID('someId'),
+      localOnly: true,
+    }
+    const { result, waitFor, waitForNextUpdate } = renderHook(
+      () => useLazyPendingIDSpecificOperation(),
+      {
+        wrapper: wrapper(testConfiguration.identity, testConfiguration.path),
+      },
+    )
+
+    // we wait for the Ditto instance to load.
+    await waitForNextUpdate()
+    await result.current.exec(params)
+    await waitFor(() => !!result.current.document, { timeout: 5000 })
+
+    expect(result.current.document._id.toString()).to.eq('"someId"')
+    expect(result.current.document._value.document).to.eq(1)
+
+    expect(result.current.ditto).not.to.eq(undefined)
+    expect(result.current.liveQuery).not.to.eq(undefined)
+    expect(result.current.event).not.to.eq(undefined)
+  })
+
   it('should return the loaded Ditto collection so developers can launch queries on the store with it, once the exec function is called', async function () {
     const testConfiguration = testIdentity()
 

--- a/src/queries/useLazyPendingIDSpecificOperation.ts
+++ b/src/queries/useLazyPendingIDSpecificOperation.ts
@@ -70,12 +70,22 @@ export function useLazyPendingIDSpecificOperation<
 
     if (nextDitto) {
       const nextCollection = nextDitto.store.collection(params.collection)
-      liveQueryRef.current = nextCollection
-        .findByID(params._id)
-        .observe((doc: T, e) => {
-          setEvent(e)
-          setDocument(doc)
-        })
+
+      if (!!params.localOnly) {
+        liveQueryRef.current = nextCollection
+          .findByID(params._id)
+          .observeLocal((doc: T, e) => {
+            setEvent(e)
+            setDocument(doc)
+          })
+      } else {
+        liveQueryRef.current = nextCollection
+          .findByID(params._id)
+          .observe((doc: T, e) => {
+            setEvent(e)
+            setDocument(doc)
+          })
+      }
 
       setDitto(nextDitto)
       setCollection(nextCollection)

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -110,6 +110,31 @@ describe('usePendingCursorOperation tests', function () {
     }
   })
 
+  it('should load all documents correctly observing only for local data', async () => {
+    const testConfiguration = testIdentity()
+
+    const params: LiveQueryParams = {
+      path: testConfiguration.path,
+      collection: 'foo',
+      localOnly: true,
+    }
+    const { result, waitFor } = renderHook(
+      () => usePendingCursorOperation(params),
+      {
+        wrapper: wrapper(testConfiguration.identity, testConfiguration.path),
+      },
+    )
+    await waitFor(() => !!result.current.documents?.length, { timeout: 5000 })
+
+    expect(result.current.documents.length).to.eq(5)
+
+    for (let i = 1; i < 6; i++) {
+      expect(
+        !!result.current.documents.find((doc) => doc._value.document === i),
+      ).to.eq(true)
+    }
+  })
+
   it('should load documents correctly using a query', async () => {
     const testConfiguration = testIdentity()
 

--- a/src/queries/usePendingCursorOperation.ts
+++ b/src/queries/usePendingCursorOperation.ts
@@ -67,6 +67,8 @@ export interface LiveQueryParams {
    * An optional number to use as an offset of the results of the query. If you omit this value, an offset of 0 is assumed.
    */
   offset?: number
+  /** When true the query will only on local data mutations and will not rely on replication. */
+  localOnly?: boolean
 }
 
 export interface PendingCursorOperationReturn<T> {
@@ -132,10 +134,18 @@ export function usePendingCursorOperation<T = DocumentLike>(
       if (params.offset) {
         cursor = cursor.offset(params.offset)
       }
-      liveQueryRef.current = cursor.observe((docs, event) => {
-        setDocuments(docs)
-        setLiveQueryEvent(event)
-      })
+
+      if (!!params.localOnly) {
+        liveQueryRef.current = cursor.observeLocal((docs, event) => {
+          setDocuments(docs)
+          setLiveQueryEvent(event)
+        })
+      } else {
+        liveQueryRef.current = cursor.observe((docs, event) => {
+          setDocuments(docs)
+          setLiveQueryEvent(event)
+        })
+      }
 
       setCollection(nextCollection)
     }

--- a/src/queries/usePendingIDSpecificOperation.spec.tsx
+++ b/src/queries/usePendingIDSpecificOperation.spec.tsx
@@ -110,6 +110,27 @@ describe('usePendingIDSpecificOperation tests', function () {
     expect(result.current.document._value.document).to.eq(1)
   })
 
+  it('should load a document by ID correctly observing only the local store', async () => {
+    const testConfiguration = testIdentity()
+
+    const params: UsePendingIDSpecificOperationParams = {
+      path: testConfiguration.path,
+      collection: 'foo',
+      _id: new DocumentID('someId'),
+      localOnly: true,
+    }
+    const { result, waitFor } = renderHook(
+      () => usePendingIDSpecificOperation(params),
+      {
+        wrapper: wrapper(testConfiguration.identity, testConfiguration.path),
+      },
+    )
+    await waitFor(() => !!result.current.document, { timeout: 5000 })
+
+    expect(result.current.document._id.toString()).to.eq('"someId"')
+    expect(result.current.document._value.document).to.eq(1)
+  })
+
   it('should return the loaded Ditto collection so developers can launch queries on the store with it', async function () {
     const testConfiguration = testIdentity()
 


### PR DESCRIPTION
# Problem

The react ditto library has no way pass down local only live queries to the `usePendingCursorOperation` and `usePendingIDSpecificOperation` hooks. 

# Solution

Add an optional param called `localOnly` which takes a boolean. If omitted, it will be `false`. If `true`, then the live query will only run on local data mutations and will not replicate

```ts
usePendingCursorOperation({ 
  localOnly: true // if omitted this will be false
})
```