### PR TITLE
Introduce useDittoContext hook

### DIFF
--- a/src/DittoContext.tsx
+++ b/src/DittoContext.tsx
@@ -1,5 +1,5 @@
 import { Ditto } from '@dittolive/ditto'
-import { createContext } from 'react'
+import { createContext, useContext } from 'react'
 
 export interface DittoHash {
   [key: string]: Ditto
@@ -25,3 +25,10 @@ export const DittoContext = createContext<DittoContextProps>({
   load: () => Promise.resolve(),
   isLazy: false,
 })
+
+export const useDittoContext = (): DittoContextProps => {
+  const dittoContext = useContext(DittoContext)
+  if (!dittoContext)
+    throw new Error('useDittoContext must be called within a DittoProvider tag')
+  return dittoContext
+}

--- a/src/DittoLazyProvider.spec.tsx
+++ b/src/DittoLazyProvider.spec.tsx
@@ -1,10 +1,10 @@
 import { Ditto, IdentityOfflinePlayground } from '@dittolive/ditto'
 import { expect } from 'chai'
-import React, { useContext } from 'react'
+import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
 import { v4 as uuidv4 } from 'uuid'
 
-import { DittoContext } from './DittoContext'
+import { useDittoContext } from './DittoContext'
 import { DittoLazyProvider } from './DittoLazyProvider'
 import { waitFor } from './utils.spec'
 
@@ -142,7 +142,7 @@ describe('Ditto Lazy Provider Tests', () => {
     const config = testIdentity()
 
     const TesterChildComponent = () => {
-      const { dittoHash } = useContext(DittoContext)
+      const { dittoHash } = useDittoContext()
 
       return (
         <div data-testid="dittoHash">

--- a/src/DittoProvider.spec.tsx
+++ b/src/DittoProvider.spec.tsx
@@ -1,11 +1,11 @@
 import { Ditto, IdentityOfflinePlayground } from '@dittolive/ditto'
 // import { waitFor } from '@testing-library/react'
 import { expect } from 'chai'
-import React, { useContext } from 'react'
+import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
 import { v4 as uuidv4 } from 'uuid'
 
-import { DittoContext } from './DittoContext'
+import { useDittoContext } from './DittoContext'
 import { DittoProvider } from './DittoProvider'
 import { waitFor } from './utils.spec'
 
@@ -149,7 +149,7 @@ describe('Ditto Provider Tests', () => {
     const config = testIdentity()
 
     const TesterChildComponent = () => {
-      const { dittoHash } = useContext(DittoContext)
+      const { dittoHash } = useDittoContext()
 
       return (
         <div data-testid="dittoHash">

--- a/src/queries/useLazyPendingCursorOperation.ts
+++ b/src/queries/useLazyPendingCursorOperation.ts
@@ -6,9 +6,9 @@ import {
   LiveQueryEvent,
   PendingCursorOperation,
 } from '@dittolive/ditto'
-import { useContext, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 
-import { DittoContext } from '../DittoContext'
+import { useDittoContext } from '../DittoContext'
 import { LiveQueryParams } from './usePendingCursorOperation'
 
 export interface LazyPendingCursorOperationReturn<T> {
@@ -52,7 +52,7 @@ export interface LazyPendingCursorOperationReturn<T> {
 export function useLazyPendingCursorOperation<
   T = DocumentLike,
 >(): LazyPendingCursorOperationReturn<T> {
-  const { dittoHash, isLazy, load } = useContext(DittoContext)
+  const { dittoHash, isLazy, load } = useDittoContext()
   const [documents, setDocuments] = useState<T[]>([])
   const [liveQueryEvent, setLiveQueryEvent] = useState<
     LiveQueryEvent | undefined

--- a/src/queries/useLazyPendingIDSpecificOperation.ts
+++ b/src/queries/useLazyPendingIDSpecificOperation.ts
@@ -5,9 +5,9 @@ import {
   LiveQuery,
   SingleDocumentLiveQueryEvent,
 } from '@dittolive/ditto'
-import { useContext, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 
-import { DittoContext } from '../DittoContext'
+import { useDittoContext } from '../DittoContext'
 import { UsePendingIDSpecificOperationParams } from './usePendingIDSpecificOperation'
 
 export interface LazyPendingIDSpecificOperationReturn<T> {
@@ -48,7 +48,7 @@ export interface LazyPendingIDSpecificOperationReturn<T> {
 export function useLazyPendingIDSpecificOperation<
   T = DocumentLike,
 >(): LazyPendingIDSpecificOperationReturn<T> {
-  const { dittoHash, isLazy, load } = useContext(DittoContext)
+  const { dittoHash, isLazy, load } = useDittoContext()
   const liveQueryRef = useRef<LiveQuery>()
   const [ditto, setDitto] = useState<Ditto>()
   const [document, setDocument] = useState<T>()

--- a/src/useDitto.ts
+++ b/src/useDitto.ts
@@ -1,7 +1,7 @@
 import { Ditto } from '@dittolive/ditto'
-import { useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { DittoContext } from '.'
+import { useDittoContext } from '.'
 
 export interface DittoHookProps {
   ditto: Ditto | null
@@ -10,7 +10,7 @@ export interface DittoHookProps {
 }
 
 export const useDitto = (path: string | null | undefined): DittoHookProps => {
-  const { dittoHash, isLazy, load } = useContext(DittoContext)
+  const { dittoHash, isLazy, load } = useDittoContext()
   const [loading, setLoading] = useState(isLazy && !(path in dittoHash))
   const [error, setError] = useState<Error>()
   const ditto = !!path ? dittoHash[path] : Object.values(dittoHash)[0]


### PR DESCRIPTION
## Description
Introduces a simple `useDittoContext` wrapper to be used in favor of `useContext(DittoContext)`

## Why
Gives the added benefit of custom error messaging when user is attempting to consume the context without the required context provider. Improves code reusability.

