### PR TITLE
Optimizes the DittoLazyProvider for concurrent instance creation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^1.0.17",
+    "@dittolive/ditto": "^1.1.2",
     "@testing-library/react": "^12.1.1",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/chai": "^4.2.21",

--- a/src/DittoLazyProvider.spec.tsx
+++ b/src/DittoLazyProvider.spec.tsx
@@ -13,7 +13,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'dittoLazyProviderSpec',
+    appID: 'dittoLazyProviderSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },
@@ -47,7 +47,7 @@ describe('Ditto Lazy Provider Tests', () => {
           return (
             <>
               <div data-testid="loading">{`${loading}`}</div>
-              <div data-testid="error">{error}</div>
+              <div data-testid="error">{error?.message}</div>
             </>
           )
         }}

--- a/src/DittoLazyProvider.tsx
+++ b/src/DittoLazyProvider.tsx
@@ -1,5 +1,5 @@
 import { Ditto, init, InitOptions } from '@dittolive/ditto'
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useEffect, useRef, useState } from 'react'
 
 import {
   DittoContext,
@@ -34,6 +34,7 @@ export interface DittoLazyProviderProps
 export const DittoLazyProvider: React.FunctionComponent<DittoLazyProviderProps> =
   ({ initOptions, setup, render, children }) => {
     const [dittoHash, setDittoHash] = useState<DittoHash>({})
+    const createdPaths = useRef([])
     const [providerState, setProviderState] = useState<ProviderState>({
       loading: true,
       error: undefined,
@@ -66,9 +67,10 @@ export const DittoLazyProvider: React.FunctionComponent<DittoLazyProviderProps> 
     }
 
     const handleLoadInstance = async (appPath: string) => {
-      if (appPath in dittoHash) {
-        return dittoHash[appPath]
+      if (createdPaths.current.includes(appPath)) {
+        return dittoHash[appPath] || null
       } else {
+        createdPaths.current.push(appPath)
         /** The app path is initialized to null while loading to avoid parallel initializations
          * of the same instance.
          */

--- a/src/queries/useCollections.spec.tsx
+++ b/src/queries/useCollections.spec.tsx
@@ -14,7 +14,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'useCollectionsSpec',
+    appID: 'useCollectionsSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },

--- a/src/queries/useLazyPendingCursorOperation.spec.tsx
+++ b/src/queries/useLazyPendingCursorOperation.spec.tsx
@@ -15,7 +15,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'useLazyPendingCursorOperationSpec',
+    appID: 'useLazyPendingCursorOperationSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },
@@ -218,7 +218,10 @@ describe('useLazyPendingCursorOperation tests', function () {
       collection: 'foo',
     })
 
-    expect(result.current.documents.length).to.eql(5)
+    await waitFor(() => result.current.documents.length === 5, {
+      timeout: 5000,
+    })
+
     expect(result.current.liveQuery).not.to.eq(liveQuery)
   })
 

--- a/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
+++ b/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
@@ -15,7 +15,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'usePendingIDSpecificOperationSpec',
+    appID: 'usePendingIDSpecificOperationSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -17,7 +17,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'usePendingCursorOperationSpec',
+    appID: 'usePendingCursorOperationSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },
@@ -182,11 +182,16 @@ describe('usePendingCursorOperation tests', function () {
 
     result.current.reset()
 
-    await waitFor(() => result.current.liveQuery !== liveQueryBeforeReset, {
-      timeout: 5000,
-    })
+    expect(result.current.documents.length).to.eq(0)
 
-    expect(result.current.documents.length).to.eq(2)
+    await waitFor(
+      () =>
+        result.current.liveQuery !== liveQueryBeforeReset &&
+        result.current.documents.length === 2,
+      {
+        timeout: 5000,
+      },
+    )
   })
 
   it('should return the Ditto collection as an alternative way for developers to query the collection', async () => {

--- a/src/queries/usePendingIDSpecificOperation.spec.tsx
+++ b/src/queries/usePendingIDSpecificOperation.spec.tsx
@@ -17,7 +17,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'usePendingIDSpecificOperationSpec',
+    appID: 'usePendingIDSpecificOperationSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },

--- a/src/queries/usePendingIDSpecificOperation.ts
+++ b/src/queries/usePendingIDSpecificOperation.ts
@@ -67,22 +67,23 @@ export function usePendingIDSpecificOperation<T = DocumentLike>(
   const [event, setEvent] = useState<SingleDocumentLiveQueryEvent>()
 
   useEffect(() => {
-    let liveQuery: LiveQuery
     if (params._id && params.collection && ditto) {
       const nextCollection = ditto.store.collection(params.collection)
 
       if (!!params.localOnly) {
-        liveQuery = nextCollection
+        liveQueryRef.current = nextCollection
           .findByID(params._id)
           .observeLocal((doc: T, e) => {
             setEvent(e)
             setDocument(doc)
           })
       } else {
-        liveQuery = nextCollection.findByID(params._id).observe((doc: T, e) => {
-          setEvent(e)
-          setDocument(doc)
-        })
+        liveQueryRef.current = nextCollection
+          .findByID(params._id)
+          .observe((doc: T, e) => {
+            setEvent(e)
+            setDocument(doc)
+          })
       }
       setCollection(nextCollection)
     } else {
@@ -91,7 +92,7 @@ export function usePendingIDSpecificOperation<T = DocumentLike>(
       setEvent(undefined)
     }
     return () => {
-      liveQuery?.stop()
+      liveQueryRef.current?.stop()
     }
     /** We need to serialize the _id in order for React's dependency array comparison to work. */
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,10 +883,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@dittolive/ditto@^1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.0.17.tgz#6a58277c97f473e9eabff6d333a2467e63166470"
-  integrity sha512-jnLtUkhlb5ZubWwfvijKZ+KgXHjbmZaTG6uVo7ZpqjxHs87I7kTvvI9NqHytkkwFukA2u6cAehu0xdub/XXFVg==
+"@dittolive/ditto@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.2.tgz#e09135be15727b76282fb38f1cfd5c017eedea39"
+  integrity sha512-yXTC6u8HumeMq8QGE8t9B2shi6SryFhXz4GMHeKkNxggqjvLZjMSPrT9mk5Wib26rYUbqgvcxxLVVusZHJQUtQ==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
The previous implementation could cause multiple ditto instances belonging to the same path to be created if the load function was called multiple times before the setDittoHash render cycle kicked in. We now maintain a ref with all the paths that have been created, in order to immediately track the path for which a Ditto instance has been created or is in the process of being created.

The SDK dependency has been updated, and some tests have been optinised to make them more robust.