### PR TITLE
Only deploy docs on pushes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: yarn docs:generate
         
       - name: Deploy Documentation Website 🚀
+        if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages # The branch the action should deploy to.


### PR DESCRIPTION
[This commit](https://github.com/getditto/react-ditto/commit/4af0738dc44a073efb3086348fa3986d0821ee8f) pushed to a branch different from `master` triggered [an update to the docs](https://github.com/getditto/react-ditto/commit/8f942ebb7a16f36f5100348fed0ed47bd15d4825).

We should only deploy docs from `master`. The [CI run](https://github.com/getditto/react-ditto/runs/5774652684) for this PR's branch successfully skipped that build step.