### PR TITLE
Removes the authentication function from the useOnlineIdentity hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const createDittoInstance = (forPath: string) => {
 ```
 
 ```ts
-const { create, getAuthenticationRequired, getTokenExpiresInSeconds, authenticate } = useOnlineIdentity()
+const { create, getAuthenticationRequired, getTokenExpiresInSeconds } = useOnlineIdentity()
 
 const createDittoInstance = (forPath: string) => {
   // Example of how to create an online instance with authentication enabled
@@ -251,29 +251,40 @@ Using the [Portal](http://portal.ditto.live) you can create apps that sync to th
 
 ```tsx
 /** Example of a React root component setting up a single ditto instance that uses a development connection */
+import { useEffect } from 'react'
+
 const RootComponent = () => {
-  const { create, getAuthenticationRequired, getTokenExpiresInSeconds, authenticate } = useOnlineIdentity()
-  
+  const { create, getAuthenticationRequired, getTokenExpiresInSeconds } = useOnlineIdentity()
+
   return (
     <>
-        <DittoProvider 
-          setup={() => new Ditto(create({ appID: 'your-app-id', path: '/my-online-path' }, '/my-online-path'))} 
-          /*initOptions={initOptions} */
-        >
-          {({ loading, error, ditto }) => {
-            if (loading) return <p>Loading</p>;
-            if (error) return <p>{error.message}</p>;
-            return <App />;
-          }}
-        </DittoProvider>
-        {getAuthenticationRequired('/my-online-path') && (
-          <div>
-            <div>You need to authenticate!</div>
-            <button onClick={() => authenticate('/my-online-path', 'provider', 'some token')}>Authenticate</button>
-          </div>
-        )}
+      <DittoProvider
+        setup={() => new Ditto(create({ appID: 'your-app-id', path: '/my-online-path' }, '/my-online-path'))}
+        /*initOptions={initOptions} */
+      >
+        {({ loading, error, ditto }) => {
+          if (loading) return <p>Loading</p>;
+          if (error) return <p>{error.message}</p>;
+          return <App />;
+        }}
+      </DittoProvider>
     </>
   )
+}
+
+const App = () => {
+  const ditto = useDitto()
+
+  useEffect(() => {
+    if(ditto) {
+      ditto
+        .auth
+        .loginWithToken('token', 'provider')
+        .then(() => console.log("Login successful"))
+    }
+  }, [ditto])
+  
+  return (<div>Hello world!</div>)
 }
 
 ```
@@ -283,7 +294,6 @@ For Online apps, the `useOnlineIdentity` hook returns the following set of prope
 * `create`: Creates an `onlineWithAuthentication` object preconfigured such that the hook can manage the authentication flow using the exposed `authenticate` function.
 * `getAuthenticationRequired`: Is a function that takes in the app path for which to check the authentication required state, and will return true if your Ditto instance is requiring the current user to authenticate with the app. You can configure authentication webhooks on the [Portal](http://portal.ditto.live), from your app settings area, in order to provide your own set of validation services for your app.
 * `getTokenExpiresInSeconds`: Is a function that takes in the app path for which to check the token expiry second, and returns the number of seconds in which your current token expires if this has been reported by the Ditto SDK.
-* `authenticate`: Function that can be used to make an authentication request for an app given the app path. Requires you to provide the token and the provider name (taken from the list of the configured token validation providers) that you want to validate the token against.
 
 ## Building this library and running tests
 

--- a/examples/create-react-app-typescript-example/src/AppContainer.tsx
+++ b/examples/create-react-app-typescript-example/src/AppContainer.tsx
@@ -25,15 +25,11 @@ const options: IdentityOption[] = [
  * */
 const AppContainer: React.FC = () => {
   const { create: createDevelopment } = useOfflinePlaygroundIdentity()
-  const {
-    create: createOnline,
-    getAuthenticationRequired,
-    authenticate,
-  } = useOnlineIdentity()
+  const { create: createOnline, getAuthenticationRequired } =
+    useOnlineIdentity()
   const [currentPath, setCurrentPath] = useState('/path-development')
 
   const handleCreateDittoInstances = () => {
-    console.log('CREATING INSTANCES')
     // Example of how to create a development instance
     const dittoDevelopment = new Ditto(
       createDevelopment({ appName: 'live.ditto.example', siteID: 1234 }),
@@ -87,16 +83,17 @@ const AppContainer: React.FC = () => {
             return <h1>Error: {JSON.stringify(error)}</h1>
           }
 
-          return <App path={currentPath} />
+          return (
+            <>
+              <App path={currentPath} />
+              <AuthenticationPanel
+                path={currentPath}
+                isAuthRequired={getAuthenticationRequired(currentPath)}
+              />
+            </>
+          )
         }}
       </DittoProvider>
-      {getAuthenticationRequired(currentPath) && (
-        <AuthenticationPanel
-          onSubmit={(token, provider) =>
-            authenticate(currentPath, provider, token)
-          }
-        />
-      )}
     </>
   )
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url" : "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "^1.0.17",
+    "@dittolive/ditto": "^1.1.6",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^1.1.2",
+    "@dittolive/ditto": "^1.1.6",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url" : "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "^1.1.6",
+    "@dittolive/ditto": "1.1.5",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^1.1.6",
+    "@dittolive/ditto": "1.1.5",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittolive/react-ditto",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "React wrappers for Ditto",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/identity/useOnlineIdentity.spec.tsx
+++ b/src/identity/useOnlineIdentity.spec.tsx
@@ -15,7 +15,6 @@ describe('Ditto useOnlineIdentity hook tests', () => {
     expect(result.current.create).to.exist
     expect(result.current.getAuthenticationRequired).to.exist
     expect(result.current.getTokenExpiresInSeconds).to.exist
-    expect(result.current.authenticate).to.exist
 
     const identity = result.current.create({ appID }, 'app')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,10 +903,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@dittolive/ditto@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.2.tgz#e09135be15727b76282fb38f1cfd5c017eedea39"
-  integrity sha512-yXTC6u8HumeMq8QGE8t9B2shi6SryFhXz4GMHeKkNxggqjvLZjMSPrT9mk5Wib26rYUbqgvcxxLVVusZHJQUtQ==
+"@dittolive/ditto@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.6.tgz#e305d715b6050ce4d2978beb96db25cedce442c6"
+  integrity sha512-+FRdUbRRlyvm1nay1V+KQ255M82nsiD08inJiZ/MSIsKH6LJB0o4Hb2Bz5/85U0abjXu2YzI12tBnp0Ffq6ioA==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,10 +903,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@dittolive/ditto@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.6.tgz#e305d715b6050ce4d2978beb96db25cedce442c6"
-  integrity sha512-+FRdUbRRlyvm1nay1V+KQ255M82nsiD08inJiZ/MSIsKH6LJB0o4Hb2Bz5/85U0abjXu2YzI12tBnp0Ffq6ioA==
+"@dittolive/ditto@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.5.tgz#b5f74b4b224099a8874b4dcb7a3b6f75c0799fbb"
+  integrity sha512-D2n9k2Z60hmR9H1f+QdSOtD81QMmAkkMIf5528BrM/DlOKcwswCR/vmVAGBHuZ4j/2PLgtX7eGcQqGe036jiWw==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Authentication needs to be done through the  instance using the ditto.auth.login functions. This PR removes  `authenticate` from `useOnlineIdenty` and updates the internal implementation of getAuthenticationRequired and getTokenExpiresInSeconds.

This fixes a bug whereby calls to `authenticate` were only reporting errors the first time authenticate was called and not in subsequent calls. 