### PR TITLE
Upgrade `@dittolive/ditto` peer dependency and replace `insert` with `upsert`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It is important to highlight that choosing one provider or the other has no effe
 
 ```tsx
 const createDittoInstance = () => {
-  return new Ditto(createIdentity(), "some-path")
+  return new Ditto(createIdentity(), 'some-path')
 }
 
 <DittoProvider setup={createDittoInstance}>
@@ -166,7 +166,7 @@ import { DittoProvider, useOfflinePlaygroundIdentity } from '@dittolive/react-di
  * the wasm will be loaded from our CDN.
  **/
 const initOptions = {
-  webAssemblyModule: "/ditto.wasm",
+  webAssemblyModule: '/ditto.wasm',
 }
 
 /** Example of a React root component setting up a single ditto instance that uses a development connection */
@@ -193,14 +193,14 @@ ReactDOM.render(
   <React.StrictMode>
     <RootComponent />
   </React.StrictMode>,
-  document.getElementById("root")
+  document.getElementById('root')
 );
 ```
 
 3. In your `App` component, you can now use hooks like `usePendingCursorOperation` or `usePendingIDSpecificOperation` to get your documents like so:
 
 ```tsx
-import { usePendingCursorOperation, useMutations } from "@dittolive/react-ditto";
+import { usePendingCursorOperation, useMutations } from '@dittolive/react-ditto';
 
 export default function App() {
   const { documents, ditto } = usePendingCursorOperation({
@@ -224,7 +224,7 @@ export default function App() {
 Alternatively, you can also choose to go with the lazy variants of these hooks (`useLazyPendingCursorOperation` and `useLazyPendingIDSpecificOperation`), ir order to launch queries on the data store as a response to a user event:
 
 ```tsx
-import { usePendingCursorOperation, useMutations } from "@dittolive/react-ditto";
+import { usePendingCursorOperation, useMutations } from '@dittolive/react-ditto';
 
 export default function App() {
   const { documents, ditto, exec } = useLazyPendingCursorOperation();
@@ -280,7 +280,7 @@ const App = () => {
       ditto
         .auth
         .loginWithToken('token', 'provider')
-        .then(() => console.log("Login successful"))
+        .then(() => console.log('Login successful'))
     }
   }, [ditto])
   

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ export default function App() {
     collection: 'tasks',
   });
 
-  const { updateByID, insert } = useMutations({ collection: 'tasks' })
+  const { updateByID, upsert } = useMutations({ collection: 'tasks' })
 
   return (
     <ul>

--- a/examples/create-react-app-typescript-example/src/App.tsx
+++ b/examples/create-react-app-typescript-example/src/App.tsx
@@ -24,7 +24,7 @@ const App: React.FC<Props> = ({ path }) => {
     [path],
   )
   const { documents: tasks } = usePendingCursorOperation<Task>(params)
-  const { insert, removeByID, updateByID } = useMutations<Task>({
+  const { upsert, removeByID, updateByID } = useMutations<Task>({
     collection: 'tasks',
     path: path,
   })
@@ -44,7 +44,7 @@ const App: React.FC<Props> = ({ path }) => {
         <button
           type="button"
           onClick={() => {
-            insert({
+            upsert({
               value: {
                 body: newBodyText,
                 isCompleted: false,

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url" : "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "1.1.5",
+    "@dittolive/ditto": "^1.1.10",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "1.1.5",
+    "@dittolive/ditto": "^1.1.10",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/src/DittoLazyProvider.spec.tsx
+++ b/src/DittoLazyProvider.spec.tsx
@@ -45,6 +45,7 @@ describe('Ditto Lazy Provider Tests', () => {
   }
 
   it('should load ditto wasm from the CDN', async function () {
+    this.timeout(10_000)
     const config = testIdentity()
 
     root.render(

--- a/src/DittoProvider.spec.tsx
+++ b/src/DittoProvider.spec.tsx
@@ -45,6 +45,7 @@ describe('Ditto Provider Tests', () => {
   }
 
   it('should load ditto wasm from the CDN', async function () {
+    this.timeout(10_000)
     const config = testIdentity()
 
     root.render(

--- a/src/mutations/useMutations.spec.tsx
+++ b/src/mutations/useMutations.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Ditto, IdentityOfflinePlayground } from '@dittolive/ditto'
 import { renderHook, waitFor } from '@testing-library/react'
@@ -56,13 +55,11 @@ describe('useMutations tests', function () {
     )
     await waitFor(() => expect(mutations.current.ditto).to.exist)
 
-    const insertResult = await mutations.current.insert({
-      value: { foo: 'bar' },
-      insertOptions: { id: 'some_id' },
+    const upsertResult = await mutations.current.upsert({
+      value: { _id: 'some_id', foo: 'bar' },
     })
 
-    // @ts-ignore
-    expect(insertResult).to.eql('some_id')
+    expect(upsertResult).to.eql('some_id')
 
     const updateResult = await mutations.current.updateByID({
       _id: 'some_id',
@@ -104,17 +101,14 @@ describe('useMutations tests', function () {
 
     await waitFor(() => expect(mutations.current.ditto).to.exist)
 
-    await mutations.current.insert({
-      value: { type: 'car', wheels: 4 },
-      insertOptions: { id: 'car' },
+    await mutations.current.upsert({
+      value: { _id: 'car', type: 'car', wheels: 4 },
     })
-    await mutations.current.insert({
-      value: { type: 'skate', wheels: 4 },
-      insertOptions: { id: 'skate' },
+    await mutations.current.upsert({
+      value: { _id: 'skate', type: 'skate', wheels: 4 },
     })
-    await mutations.current.insert({
-      value: { type: 'bike', wheels: 2 },
-      insertOptions: { id: 'bike' },
+    await mutations.current.upsert({
+      value: { _id: 'bike', type: 'bike', wheels: 2 },
     })
 
     const updateResult = await mutations.current.update({

--- a/src/mutations/useMutations.ts
+++ b/src/mutations/useMutations.ts
@@ -3,12 +3,12 @@ import {
   DocumentIDValue,
   DocumentLike,
   DocumentValue,
-  InsertOptions,
   PendingCursorOperation,
   PendingIDSpecificOperation,
   QueryArguments,
   UpdateResult,
   UpdateResultsMap,
+  UpsertOptions,
 } from '@dittolive/ditto'
 import { useCallback } from 'react'
 
@@ -49,13 +49,13 @@ export type UpdateByIDFunction<T> = (
   params: UpdateByIDParams<T>,
 ) => Promise<UpdateResult[]>
 
-export interface InsertParams<T> {
+export interface UpsertParams<T> {
   value: T
-  insertOptions?: InsertOptions
+  upsertOptions?: UpsertOptions
 }
 
-export type InsertFunction<T> = (
-  params: InsertParams<T>,
+export type UpsertFunction<T> = (
+  params: UpsertParams<T>,
 ) => Promise<DocumentIDValue>
 
 export interface RemoveParams {
@@ -90,7 +90,7 @@ export function useMutations<T = DocumentLike>(
   ditto: Ditto
   update: UpdateFunction<T>
   updateByID: UpdateByIDFunction<T>
-  insert: InsertFunction<T>
+  upsert: UpsertFunction<T>
   remove: RemoveFunction
   removeByID: RemoveByIDFunction
 } {
@@ -129,11 +129,11 @@ export function useMutations<T = DocumentLike>(
     [ditto, useMutationParams.collection],
   )
 
-  const insert: InsertFunction<T> = useCallback(
+  const upsert: UpsertFunction<T> = useCallback(
     (params) => {
       return ditto.store
         .collection(useMutationParams.collection)
-        .insert(params.value as unknown as DocumentValue, params.insertOptions)
+        .upsert(params.value as unknown as DocumentValue, params.upsertOptions)
     },
     [ditto, useMutationParams.collection],
   )
@@ -173,7 +173,7 @@ export function useMutations<T = DocumentLike>(
     ditto,
     update,
     updateByID,
-    insert,
+    upsert,
     remove,
     removeByID,
   }

--- a/src/queries/useCollections.spec.tsx
+++ b/src/queries/useCollections.spec.tsx
@@ -28,16 +28,16 @@ describe('useCollections tests', function () {
     }
 
     const TestComponent: React.FC = () => {
-      const { ditto, insert } = useMutations<unknown>({
+      const { ditto, upsert } = useMutations<unknown>({
         path: testConfiguration.path,
         collection: 'foo',
       })
 
       useEffect(() => {
         if (ditto) {
-          insert({ value: { document: 1 } })
+          upsert({ value: { document: 1 } })
         }
-      }, [ditto, insert])
+      }, [ditto, upsert])
 
       return <></>
     }

--- a/src/queries/useLazyPendingCursorOperation.spec.tsx
+++ b/src/queries/useLazyPendingCursorOperation.spec.tsx
@@ -8,7 +8,7 @@ import { DittoProvider } from '../DittoProvider'
 import { waitForNextUpdate } from '../utils.spec'
 import { useLazyPendingCursorOperation } from './useLazyPendingCursorOperation'
 import { LiveQueryParams } from './usePendingCursorOperation'
-import { DocumentInserter } from './usePendingCursorOperation.spec'
+import { DocumentUpserter } from './usePendingCursorOperation.spec'
 
 const testIdentity: () => {
   identity: IdentityOfflinePlayground
@@ -42,7 +42,7 @@ const wrapper =
         {() => {
           return (
             <>
-              <DocumentInserter path={path} />
+              <DocumentUpserter path={path} />
               {children}
             </>
           )

--- a/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
+++ b/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
@@ -22,24 +22,19 @@ const testIdentity: () => {
   path: uuidv4(),
 })
 
-const DocumentInserter: React.FC<{ path: string }> = ({ path }) => {
-  const { ditto, insert } = useMutations<unknown>({
+const DocumentUpserter: React.FC<{ path: string }> = ({ path }) => {
+  const { ditto, upsert } = useMutations<unknown>({
     path,
     collection: 'foo',
   })
 
   useEffect(() => {
     if (ditto) {
-      insert({
-        value: { document: 1 },
-        insertOptions: {
-          id: 'someId',
-        },
-      })
-      insert({ value: { document: 2 } })
-      insert({ value: { document: 3 } })
-      insert({ value: { document: 4 } })
-      insert({ value: { document: 5 } })
+      upsert({ value: { _id: 'someId', document: 1 } })
+      upsert({ value: { document: 2 } })
+      upsert({ value: { document: 3 } })
+      upsert({ value: { document: 4 } })
+      upsert({ value: { document: 5 } })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ditto])
@@ -66,7 +61,7 @@ const wrapper =
         {() => {
           return (
             <>
-              <DocumentInserter path={path} />
+              <DocumentUpserter path={path} />
               {children}
             </>
           )

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -23,19 +23,19 @@ const testIdentity: () => {
   path: uuidv4(),
 })
 
-export const DocumentInserter: React.FC<{ path: string }> = ({ path }) => {
-  const { ditto, insert } = useMutations<unknown>({
+export const DocumentUpserter: React.FC<{ path: string }> = ({ path }) => {
+  const { ditto, upsert } = useMutations<unknown>({
     path,
     collection: 'foo',
   })
 
   useEffect(() => {
     if (ditto) {
-      insert({ value: { document: 1 } })
-      insert({ value: { document: 2 } })
-      insert({ value: { document: 3 } })
-      insert({ value: { document: 4 } })
-      insert({ value: { document: 5 } })
+      upsert({ value: { document: 1 } })
+      upsert({ value: { document: 2 } })
+      upsert({ value: { document: 3 } })
+      upsert({ value: { document: 4 } })
+      upsert({ value: { document: 5 } })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ditto])
@@ -63,7 +63,7 @@ const wrapper =
         {() => {
           return (
             <>
-              <DocumentInserter path={path} />
+              <DocumentUpserter path={path} />
               {children}
             </>
           )

--- a/src/queries/usePendingIDSpecificOperation.spec.tsx
+++ b/src/queries/usePendingIDSpecificOperation.spec.tsx
@@ -23,24 +23,19 @@ const testIdentity: () => {
   path: uuidv4(),
 })
 
-const DocumentInserter: React.FC<{ path: string }> = ({ path }) => {
-  const { ditto, insert } = useMutations<unknown>({
+const DocumentUpserter: React.FC<{ path: string }> = ({ path }) => {
+  const { ditto, upsert } = useMutations<unknown>({
     path,
     collection: 'foo',
   })
 
   useEffect(() => {
     if (ditto) {
-      insert({
-        value: { document: 1 },
-        insertOptions: {
-          id: 'someId',
-        },
-      })
-      insert({ value: { document: 2 } })
-      insert({ value: { document: 3 } })
-      insert({ value: { document: 4 } })
-      insert({ value: { document: 5 } })
+      upsert({ value: { _id: 'someId', document: 1 } })
+      upsert({ value: { document: 2 } })
+      upsert({ value: { document: 3 } })
+      upsert({ value: { document: 4 } })
+      upsert({ value: { document: 5 } })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ditto])
@@ -67,7 +62,7 @@ const wrapper =
         {() => {
           return (
             <>
-              <DocumentInserter path={path} />
+              <DocumentUpserter path={path} />
               {children}
             </>
           )

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,10 +903,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@dittolive/ditto@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.5.tgz#b5f74b4b224099a8874b4dcb7a3b6f75c0799fbb"
-  integrity sha512-D2n9k2Z60hmR9H1f+QdSOtD81QMmAkkMIf5528BrM/DlOKcwswCR/vmVAGBHuZ4j/2PLgtX7eGcQqGe036jiWw==
+"@dittolive/ditto@^1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.10.tgz#2a0e5a1a1d1ec556ebc5c18d628da008f5775a3b"
+  integrity sha512-7PVPb5wxaEHYBCiO2GV2lrcrJ/ijtk3zGgoQ7wyM0+9mH2KbT1fzPf0xKfOlwKULwhYQ1+pQSxajxFN/4WLB2Q==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Related issue: #27

Versions of `@dittolive/ditto` compatible with v1.1.10 are now allowed as a peer dependency. Besides removing `insert` in favor of `upsert`, `InsertParams` and `InsertFunction` have also been dropped in favor of `UpsertParams` and `UpsertFunction`, respectively.

The idea would be to release this as v0.8.0. I'll then follow up with a new PR for v0.9.0 which will use v2 of `@dittolive/ditto` as a peer dependency.