### PR TITLE
Prepare for `@dittolive/ditto` v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "^1.1.10",
+    "@dittolive/ditto": "^2.0.0-alpha1",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^1.1.10",
+    "@dittolive/ditto": "^2.0.0-alpha1",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/src/DittoProvider.spec.tsx
+++ b/src/DittoProvider.spec.tsx
@@ -17,7 +17,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'dittoProviderSpec',
+    appID: 'dittoProviderSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },

--- a/src/identity/useOfflinePlaygroundIdentity.spec.ts
+++ b/src/identity/useOfflinePlaygroundIdentity.spec.ts
@@ -9,11 +9,11 @@ describe('Ditto useDevelopmentIdentity hook tests', () => {
 
     expect(result.current.create).to.exist
 
-    const identity = result.current.create({ appName: 'my-app', siteID: 1234 })
+    const identity = result.current.create({ appID: 'my-app', siteID: 1234 })
 
     expect(identity).to.eql({
       type: 'offlinePlayground',
-      appName: 'my-app',
+      appID: 'my-app',
       siteID: 1234,
     })
   })

--- a/src/identity/useOfflinePlaygroundIdentity.ts
+++ b/src/identity/useOfflinePlaygroundIdentity.ts
@@ -1,7 +1,7 @@
 import { IdentityOfflinePlayground } from '@dittolive/ditto'
 
 export interface CreateOfflinePlaygroundIdentityParams {
-  appName: string
+  appID: string
   siteID: number | BigInt
 }
 
@@ -24,14 +24,14 @@ export const useOfflinePlaygroundIdentity = (): {
 } => {
   return {
     create: ({
-      appName,
+      appID,
       siteID,
     }: CreateOfflinePlaygroundIdentityParams): IdentityOfflinePlayground => {
       return {
-        appName,
+        appID,
         siteID,
         type: 'offlinePlayground',
-      } as IdentityOfflinePlayground
+      }
     },
   }
 }

--- a/src/mutations/useMutations.spec.tsx
+++ b/src/mutations/useMutations.spec.tsx
@@ -13,7 +13,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'useMutationsSpec',
+    appID: 'useMutationsSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },
@@ -63,7 +63,7 @@ describe('useMutations tests', function () {
 
     const updateResult = await mutations.current.updateByID({
       _id: 'some_id',
-      updateClosure: (doc: any) => (doc.foo = 'updated'),
+      updateClosure: (doc) => doc.at('foo').set('updated'),
     })
 
     expect(updateResult.length).to.eq(1)

--- a/src/mutations/useMutations.ts
+++ b/src/mutations/useMutations.ts
@@ -1,8 +1,9 @@
 import {
   Ditto,
+  Document,
   DocumentIDValue,
-  DocumentLike,
   DocumentValue,
+  MutableDocument,
   PendingCursorOperation,
   PendingIDSpecificOperation,
   QueryArguments,
@@ -14,7 +15,7 @@ import { useCallback } from 'react'
 
 import { useDitto } from '../useDitto'
 
-export interface UpdateParams<T> {
+export interface UpdateParams {
   /**
    * A Ditto query that specifies the documents to update. If this is omitted, then the `updateClosure` will
    * apply to _all documents_.
@@ -27,14 +28,12 @@ export interface UpdateParams<T> {
   /**
    * A function used to update all the documents
    */
-  updateClosure: (mutableDocuments: T[]) => void
+  updateClosure: (mutableDocuments: MutableDocument[]) => void
 }
 
-export type UpdateFunction<T> = (
-  params: UpdateParams<T>,
-) => Promise<UpdateResultsMap>
+export type UpdateFunction = (params: UpdateParams) => Promise<UpdateResultsMap>
 
-export interface UpdateByIDParams<T> {
+export interface UpdateByIDParams {
   /**
    * The _id of the document to remove
    */
@@ -42,11 +41,11 @@ export interface UpdateByIDParams<T> {
   /**
    * The update function to perform on the specified document
    */
-  updateClosure: (mutableDocument: T) => void
+  updateClosure: (mutableDocument: MutableDocument) => void
 }
 
-export type UpdateByIDFunction<T> = (
-  params: UpdateByIDParams<T>,
+export type UpdateByIDFunction = (
+  params: UpdateByIDParams,
 ) => Promise<UpdateResult[]>
 
 export interface UpsertParams<T> {
@@ -84,19 +83,19 @@ export interface UseMutationParams {
   collection: string
 }
 
-export function useMutations<T = DocumentLike>(
+export function useMutations<T = Document>(
   useMutationParams: UseMutationParams,
 ): {
   ditto: Ditto
-  update: UpdateFunction<T>
-  updateByID: UpdateByIDFunction<T>
+  update: UpdateFunction
+  updateByID: UpdateByIDFunction
   upsert: UpsertFunction<T>
   remove: RemoveFunction
   removeByID: RemoveByIDFunction
 } {
   const { ditto } = useDitto(useMutationParams.path)
 
-  const update: UpdateFunction<T> = useCallback(
+  const update: UpdateFunction = useCallback(
     (params) => {
       let cursor: PendingCursorOperation
       if (params.query) {
@@ -117,12 +116,12 @@ export function useMutations<T = DocumentLike>(
     [ditto, useMutationParams.collection],
   )
 
-  const updateByID: UpdateByIDFunction<T> = useCallback(
+  const updateByID: UpdateByIDFunction = useCallback(
     (params) => {
       const pendingIDSpecificOperation: PendingIDSpecificOperation = ditto.store
         .collection(useMutationParams.collection)
         .findByID(params._id)
-      return pendingIDSpecificOperation.update((mutableDoc: T) => {
+      return pendingIDSpecificOperation.update((mutableDoc) => {
         params.updateClosure(mutableDoc)
       })
     },

--- a/src/queries/useLazyPendingCursorOperation.spec.tsx
+++ b/src/queries/useLazyPendingCursorOperation.spec.tsx
@@ -105,7 +105,7 @@ describe('useLazyPendingCursorOperation tests', function () {
 
     for (let i = 1; i < 6; i++) {
       expect(
-        !!result.current.documents.find((doc) => doc._value.document === i),
+        !!result.current.documents.find((doc) => doc.value.document === i),
       ).to.eq(true)
     }
   })
@@ -134,7 +134,7 @@ describe('useLazyPendingCursorOperation tests', function () {
 
     for (let i = 1; i < 6; i++) {
       expect(
-        !!result.current.documents.find((doc) => doc._value.document === i),
+        !!result.current.documents.find((doc) => doc.value.document === i),
       ).to.eq(true)
     }
   })
@@ -164,7 +164,7 @@ describe('useLazyPendingCursorOperation tests', function () {
 
     for (let i = 4; i < 6; i++) {
       expect(
-        !!result.current.documents.find((doc) => doc._value.document === i),
+        !!result.current.documents.find((doc) => doc.value.document === i),
       ).to.eq(true)
     }
   })

--- a/src/queries/useLazyPendingCursorOperation.ts
+++ b/src/queries/useLazyPendingCursorOperation.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Ditto,
-  DocumentLike,
+  Document,
   LiveQuery,
   LiveQueryEvent,
   PendingCursorOperation,
@@ -11,11 +11,11 @@ import { useRef, useState } from 'react'
 import { useDittoContext } from '../DittoContext'
 import { LiveQueryParams } from './usePendingCursorOperation'
 
-export interface LazyPendingCursorOperationReturn<T> {
+export interface LazyPendingCursorOperationReturn {
   /** The initialized Ditto instance if one could be found for the provided path. */
   ditto: Ditto | null
   /** The set of documents found for the current query. */
-  documents: T[]
+  documents: Document[]
   /** The last LiveQueryEvent received by the query observer. */
   liveQueryEvent: LiveQueryEvent | undefined
   /** Currently active live query. */
@@ -49,11 +49,9 @@ export interface LazyPendingCursorOperationReturn<T> {
  * @param params live query parameters.
  * @returns LazyPendingCursorOperationReturn
  */
-export function useLazyPendingCursorOperation<
-  T = DocumentLike,
->(): LazyPendingCursorOperationReturn<T> {
+export function useLazyPendingCursorOperation(): LazyPendingCursorOperationReturn {
   const { dittoHash, isLazy, load } = useDittoContext()
-  const [documents, setDocuments] = useState<T[]>([])
+  const [documents, setDocuments] = useState<Document[]>([])
   const [liveQueryEvent, setLiveQueryEvent] = useState<
     LiveQueryEvent | undefined
   >()

--- a/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
+++ b/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
@@ -96,7 +96,7 @@ describe('useLazyPendingIDSpecificOperation tests', function () {
     })
 
     expect(result.current.document._id).to.eq('someId')
-    expect(result.current.document._value.document).to.eq(1)
+    expect(result.current.document.value.document).to.eq(1)
 
     expect(result.current.ditto).not.to.eq(undefined)
     expect(result.current.liveQuery).not.to.eq(undefined)
@@ -125,7 +125,7 @@ describe('useLazyPendingIDSpecificOperation tests', function () {
     })
 
     expect(result.current.document._id).to.eq('someId')
-    expect(result.current.document._value.document).to.eq(1)
+    expect(result.current.document.value.document).to.eq(1)
 
     expect(result.current.ditto).not.to.eq(undefined)
     expect(result.current.liveQuery).not.to.eq(undefined)

--- a/src/queries/useLazyPendingIDSpecificOperation.ts
+++ b/src/queries/useLazyPendingIDSpecificOperation.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Ditto,
-  DocumentLike,
+  Document,
   LiveQuery,
   SingleDocumentLiveQueryEvent,
 } from '@dittolive/ditto'
@@ -10,11 +10,11 @@ import { useRef, useState } from 'react'
 import { useDittoContext } from '../DittoContext'
 import { UsePendingIDSpecificOperationParams } from './usePendingIDSpecificOperation'
 
-export interface LazyPendingIDSpecificOperationReturn<T> {
+export interface LazyPendingIDSpecificOperationReturn {
   /** The initialized Ditto instance if one could be found for the provided path. */
   ditto: Ditto | null
-  /** The documents found for the current query. */
-  document: T | undefined
+  /** The document found for the current query. */
+  document: Document | undefined
   /** The last SingleDocumentLiveQueryEvent received by the query observer. */
   event?: SingleDocumentLiveQueryEvent
   /** Currently active live query. */
@@ -45,13 +45,11 @@ export interface LazyPendingIDSpecificOperationReturn<T> {
  * @param params live query parameters.
  * @returns LazyPendingIDSpecificOperationReturn
  */
-export function useLazyPendingIDSpecificOperation<
-  T = DocumentLike,
->(): LazyPendingIDSpecificOperationReturn<T> {
+export function useLazyPendingIDSpecificOperation(): LazyPendingIDSpecificOperationReturn {
   const { dittoHash, isLazy, load } = useDittoContext()
   const liveQueryRef = useRef<LiveQuery>()
   const [ditto, setDitto] = useState<Ditto>()
-  const [document, setDocument] = useState<T>()
+  const [document, setDocument] = useState<Document>()
   const [collection, setCollection] = useState<Collection>()
   const [event, setEvent] = useState<SingleDocumentLiveQueryEvent>()
 
@@ -74,14 +72,14 @@ export function useLazyPendingIDSpecificOperation<
       if (!!params.localOnly) {
         liveQueryRef.current = nextCollection
           .findByID(params._id)
-          .observeLocal((doc: T, e) => {
+          .observeLocal((doc, e) => {
             setEvent(e)
             setDocument(doc)
           })
       } else {
         liveQueryRef.current = nextCollection
           .findByID(params._id)
-          .observe((doc: T, e) => {
+          .observe((doc, e) => {
             setEvent(e)
             setDocument(doc)
           })

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -90,7 +90,7 @@ describe('usePendingCursorOperation tests', function () {
 
     for (let i = 1; i < 6; i++) {
       expect(
-        !!result.current.documents.find((doc) => doc._value.document === i),
+        !!result.current.documents.find((doc) => doc.value.document === i),
       ).to.eq(true)
     }
   })
@@ -114,7 +114,7 @@ describe('usePendingCursorOperation tests', function () {
 
     for (let i = 1; i < 6; i++) {
       expect(
-        !!result.current.documents.find((doc) => doc._value.document === i),
+        !!result.current.documents.find((doc) => doc.value.document === i),
       ).to.eq(true)
     }
   })
@@ -138,7 +138,7 @@ describe('usePendingCursorOperation tests', function () {
 
     for (let i = 4; i < 6; i++) {
       expect(
-        !!result.current.documents.find((doc) => doc._value.document === i),
+        !!result.current.documents.find((doc) => doc.value.document === i),
       ).to.eq(true)
     }
   })

--- a/src/queries/usePendingCursorOperation.ts
+++ b/src/queries/usePendingCursorOperation.ts
@@ -1,7 +1,7 @@
 import {
   Collection,
   Ditto,
-  DocumentLike,
+  Document,
   LiveQuery,
   LiveQueryEvent,
   PendingCursorOperation,
@@ -71,11 +71,11 @@ export interface LiveQueryParams {
   localOnly?: boolean
 }
 
-export interface PendingCursorOperationReturn<T> {
+export interface PendingCursorOperationReturn {
   /** The initialized Ditto instance if one could be found for the provided path. */
   ditto: Ditto | null
   /** The set of documents found for the current query. */
-  documents: T[]
+  documents: Document[]
   /** The last LiveQueryEvent received by the query observer. */
   liveQueryEvent: LiveQueryEvent | undefined
   /** Currently active live query. */
@@ -104,11 +104,11 @@ export interface PendingCursorOperationReturn<T> {
  * @param params live query parameters.
  * @returns
  */
-export function usePendingCursorOperation<T = DocumentLike>(
+export function usePendingCursorOperation(
   params: LiveQueryParams,
-): PendingCursorOperationReturn<T> {
+): PendingCursorOperationReturn {
   const { ditto } = useDitto(params.path)
-  const [documents, setDocuments] = useState<T[]>([])
+  const [documents, setDocuments] = useState<Document[]>([])
   const [liveQueryEvent, setLiveQueryEvent] = useState<
     LiveQueryEvent | undefined
   >()

--- a/src/queries/usePendingIDSpecificOperation.spec.tsx
+++ b/src/queries/usePendingIDSpecificOperation.spec.tsx
@@ -87,7 +87,7 @@ describe('usePendingIDSpecificOperation tests', function () {
     })
 
     expect(result.current.document._id).to.eq('someId')
-    expect(result.current.document._value.document).to.eq(1)
+    expect(result.current.document.value.document).to.eq(1)
   })
 
   it('should load a document by ID correctly observing only the local store', async () => {
@@ -107,7 +107,7 @@ describe('usePendingIDSpecificOperation tests', function () {
     })
 
     expect(result.current.document._id).to.eq('someId')
-    expect(result.current.document._value.document).to.eq(1)
+    expect(result.current.document.value.document).to.eq(1)
   })
 
   it('should return the loaded Ditto collection so developers can launch queries on the store with it', async function () {

--- a/src/queries/usePendingIDSpecificOperation.ts
+++ b/src/queries/usePendingIDSpecificOperation.ts
@@ -1,8 +1,8 @@
 import {
   Collection,
   Ditto,
+  Document,
   DocumentIDValue,
-  DocumentLike,
   LiveQuery,
   SingleDocumentLiveQueryEvent,
 } from '@dittolive/ditto'
@@ -29,11 +29,11 @@ export interface UsePendingIDSpecificOperationParams {
   localOnly?: boolean
 }
 
-export interface PendingIDSpecificOperationReturn<T> {
+export interface PendingIDSpecificOperationReturn {
   /** The initialized Ditto instance if one could be found for the provided path. */
   ditto: Ditto | null
-  /** The documents found for the current query. */
-  document: T | undefined
+  /** The document found for the current query. */
+  document: Document | undefined
   /** The last SingleDocumentLiveQueryEvent received by the query observer. */
   event?: SingleDocumentLiveQueryEvent
   /** Currently active live query. */
@@ -57,12 +57,12 @@ export interface PendingIDSpecificOperationReturn<T> {
  * @param params live query parameters.
  * @returns PendingIDSpecificOperationReturn
  */
-export function usePendingIDSpecificOperation<T = DocumentLike>(
+export function usePendingIDSpecificOperation(
   params: UsePendingIDSpecificOperationParams,
-): PendingIDSpecificOperationReturn<T> {
+): PendingIDSpecificOperationReturn {
   const liveQueryRef = useRef<LiveQuery>()
   const { ditto } = useDitto(params.path)
-  const [document, setDocument] = useState<T>()
+  const [document, setDocument] = useState<Document>()
   const [collection, setCollection] = useState<Collection>()
   const [event, setEvent] = useState<SingleDocumentLiveQueryEvent>()
 
@@ -73,14 +73,14 @@ export function usePendingIDSpecificOperation<T = DocumentLike>(
       if (!!params.localOnly) {
         liveQueryRef.current = nextCollection
           .findByID(params._id)
-          .observeLocal((doc: T, e) => {
+          .observeLocal((doc, e) => {
             setEvent(e)
             setDocument(doc)
           })
       } else {
         liveQueryRef.current = nextCollection
           .findByID(params._id)
-          .observe((doc: T, e) => {
+          .observe((doc, e) => {
             setEvent(e)
             setDocument(doc)
           })

--- a/src/useDitto.spec.tsx
+++ b/src/useDitto.spec.tsx
@@ -11,7 +11,7 @@ const testIdentity: () => {
   path: string
 } = () => ({
   identity: {
-    appName: 'useDittoSpec',
+    appID: 'useDittoSpec',
     siteID: 100,
     type: 'offlinePlayground',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,10 +903,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@dittolive/ditto@^1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-1.1.10.tgz#2a0e5a1a1d1ec556ebc5c18d628da008f5775a3b"
-  integrity sha512-7PVPb5wxaEHYBCiO2GV2lrcrJ/ijtk3zGgoQ7wyM0+9mH2KbT1fzPf0xKfOlwKULwhYQ1+pQSxajxFN/4WLB2Q==
+"@dittolive/ditto@^2.0.0-alpha1":
+  version "2.0.0-alpha1"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-2.0.0-alpha1.tgz#882c82e146ae9834131f99fb307aadfcef2695b4"
+  integrity sha512-FJ7I0u11RjrGAMhyMc76ftdjI1J6wrN7v0QOsQXEpEN0Dw3vvD5TyJIO2he6sivRxOxCfCGZW4rerFw+w9BqjQ==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Related issue: #27

With v0.8.0 (65263cde1dec48298ab2046c9c5085298e0c8504) released for compatibility with `@dittolive/ditto` v1.1.10, we can now prepare for v0.9.0 to work with v2 of the JS SDK.

Besides breaking changes like `appName` -> `appID` and `_value` -> `value`, the biggest change in this PR is that our hooks are no longer generic over their document type which used to default to `DocumentLike` and allowed for `any`. The hooks now use the `Document` type directly instead.