### PR TITLE
Use `@dittolive/ditto` v2 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "^2.0.0-alpha1",
+    "@dittolive/ditto": "^2.0.0",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^2.0.0-alpha1",
+    "@dittolive/ditto": "^2.0.0",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/src/mutations/useMutations.spec.tsx
+++ b/src/mutations/useMutations.spec.tsx
@@ -47,19 +47,16 @@ describe('useMutations tests', function () {
     )
 
     const params = { path: testConfiguration.path, collection }
-    const { result: mutations } = renderHook(
-      () => useMutations<unknown>(params),
-      {
-        wrapper,
-      },
-    )
+    const { result: mutations } = renderHook(() => useMutations(params), {
+      wrapper,
+    })
     await waitFor(() => expect(mutations.current.ditto).to.exist)
 
     const upsertResult = await mutations.current.upsert({
       value: { _id: 'some_id', foo: 'bar' },
     })
 
-    expect(upsertResult).to.eql('some_id')
+    expect(upsertResult.value).to.eql('some_id')
 
     const updateResult = await mutations.current.updateByID({
       _id: 'some_id',
@@ -92,12 +89,9 @@ describe('useMutations tests', function () {
     )
 
     const params = { path: testConfiguration.path, collection }
-    const { result: mutations } = renderHook(
-      () => useMutations<unknown>(params),
-      {
-        wrapper,
-      },
-    )
+    const { result: mutations } = renderHook(() => useMutations(params), {
+      wrapper,
+    })
 
     await waitFor(() => expect(mutations.current.ditto).to.exist)
 

--- a/src/mutations/useMutations.ts
+++ b/src/mutations/useMutations.ts
@@ -1,6 +1,6 @@
 import {
   Ditto,
-  Document,
+  DocumentID,
   DocumentIDValue,
   DocumentValue,
   MutableDocument,
@@ -37,7 +37,7 @@ export interface UpdateByIDParams {
   /**
    * The _id of the document to remove
    */
-  _id: DocumentIDValue
+  _id: DocumentID | DocumentIDValue
   /**
    * The update function to perform on the specified document
    */
@@ -48,26 +48,22 @@ export type UpdateByIDFunction = (
   params: UpdateByIDParams,
 ) => Promise<UpdateResult[]>
 
-export interface UpsertParams<T> {
-  value: T
+export interface UpsertParams {
+  value: DocumentValue
   upsertOptions?: UpsertOptions
 }
 
-export type UpsertFunction<T> = (
-  params: UpsertParams<T>,
-) => Promise<DocumentIDValue>
+export type UpsertFunction = (params: UpsertParams) => Promise<DocumentID>
 
 export interface RemoveParams {
   query?: string
   args?: QueryArguments
 }
 
-export type RemoveFunction = (
-  params: RemoveParams,
-) => Promise<DocumentIDValue[]>
+export type RemoveFunction = (params: RemoveParams) => Promise<DocumentID[]>
 
 export interface RemoveByIDParams {
-  _id: unknown | DocumentIDValue
+  _id: unknown | DocumentID
 }
 
 export type RemoveByIDFunction = (params: RemoveByIDParams) => Promise<boolean>
@@ -83,13 +79,11 @@ export interface UseMutationParams {
   collection: string
 }
 
-export function useMutations<T = Document>(
-  useMutationParams: UseMutationParams,
-): {
+export function useMutations(useMutationParams: UseMutationParams): {
   ditto: Ditto
   update: UpdateFunction
   updateByID: UpdateByIDFunction
-  upsert: UpsertFunction<T>
+  upsert: UpsertFunction
   remove: RemoveFunction
   removeByID: RemoveByIDFunction
 } {
@@ -128,17 +122,17 @@ export function useMutations<T = Document>(
     [ditto, useMutationParams.collection],
   )
 
-  const upsert: UpsertFunction<T> = useCallback(
+  const upsert: UpsertFunction = useCallback(
     (params) => {
       return ditto.store
         .collection(useMutationParams.collection)
-        .upsert(params.value as unknown as DocumentValue, params.upsertOptions)
+        .upsert(params.value, params.upsertOptions)
     },
     [ditto, useMutationParams.collection],
   )
 
   const remove: RemoveFunction = useCallback(
-    (params: RemoveParams): Promise<DocumentIDValue[]> => {
+    (params: RemoveParams): Promise<DocumentID[]> => {
       let cursor: PendingCursorOperation
       if (params.query) {
         if (params.args) {

--- a/src/queries/useCollections.spec.tsx
+++ b/src/queries/useCollections.spec.tsx
@@ -28,7 +28,7 @@ describe('useCollections tests', function () {
     }
 
     const TestComponent: React.FC = () => {
-      const { ditto, upsert } = useMutations<unknown>({
+      const { ditto, upsert } = useMutations({
         path: testConfiguration.path,
         collection: 'foo',
       })

--- a/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
+++ b/src/queries/useLazyPendingIDSpecificOperation.spec.tsx
@@ -23,7 +23,7 @@ const testIdentity: () => {
 })
 
 const DocumentUpserter: React.FC<{ path: string }> = ({ path }) => {
-  const { ditto, upsert } = useMutations<unknown>({
+  const { ditto, upsert } = useMutations({
     path,
     collection: 'foo',
   })
@@ -95,7 +95,7 @@ describe('useLazyPendingIDSpecificOperation tests', function () {
       timeout: 5000,
     })
 
-    expect(result.current.document._id).to.eq('someId')
+    expect(result.current.document.id.value).to.eq('someId')
     expect(result.current.document.value.document).to.eq(1)
 
     expect(result.current.ditto).not.to.eq(undefined)
@@ -124,7 +124,7 @@ describe('useLazyPendingIDSpecificOperation tests', function () {
       timeout: 5000,
     })
 
-    expect(result.current.document._id).to.eq('someId')
+    expect(result.current.document.id.value).to.eq('someId')
     expect(result.current.document.value.document).to.eq(1)
 
     expect(result.current.ditto).not.to.eq(undefined)

--- a/src/queries/usePendingCursorOperation.spec.tsx
+++ b/src/queries/usePendingCursorOperation.spec.tsx
@@ -24,7 +24,7 @@ const testIdentity: () => {
 })
 
 export const DocumentUpserter: React.FC<{ path: string }> = ({ path }) => {
-  const { ditto, upsert } = useMutations<unknown>({
+  const { ditto, upsert } = useMutations({
     path,
     collection: 'foo',
   })

--- a/src/queries/usePendingIDSpecificOperation.spec.tsx
+++ b/src/queries/usePendingIDSpecificOperation.spec.tsx
@@ -24,7 +24,7 @@ const testIdentity: () => {
 })
 
 const DocumentUpserter: React.FC<{ path: string }> = ({ path }) => {
-  const { ditto, upsert } = useMutations<unknown>({
+  const { ditto, upsert } = useMutations({
     path,
     collection: 'foo',
   })
@@ -86,7 +86,7 @@ describe('usePendingIDSpecificOperation tests', function () {
       timeout: 5000,
     })
 
-    expect(result.current.document._id).to.eq('someId')
+    expect(result.current.document.id.value).to.eq('someId')
     expect(result.current.document.value.document).to.eq(1)
   })
 
@@ -106,7 +106,7 @@ describe('usePendingIDSpecificOperation tests', function () {
       timeout: 5000,
     })
 
-    expect(result.current.document._id).to.eq('someId')
+    expect(result.current.document.id.value).to.eq('someId')
     expect(result.current.document.value.document).to.eq(1)
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,10 +903,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@dittolive/ditto@^2.0.0-alpha1":
-  version "2.0.0-alpha1"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-2.0.0-alpha1.tgz#882c82e146ae9834131f99fb307aadfcef2695b4"
-  integrity sha512-FJ7I0u11RjrGAMhyMc76ftdjI1J6wrN7v0QOsQXEpEN0Dw3vvD5TyJIO2he6sivRxOxCfCGZW4rerFw+w9BqjQ==
+"@dittolive/ditto@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-2.0.0.tgz#7587f7ef25c8762c421364da6cc76269ec2862db"
+  integrity sha512-tmIOiI2XzV85ISJlprR6k94vB5FenvwnKNDMIsCrgMdILzunRHsyHOZMPB+PZLT96u087SplC3abvNtaB5jMXg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
This PR switches to the stable v2 SDK and addresses type issues that came up when making the switch from the alpha version. After merging this, we should be able to release a stable v0.9.0 of `react-ditto`.

Changes:
- feat: upgrade `@dittolive/ditto` to v2.0.0
- fix: use `DocumentID` as ID type instead of `DocumentIDValue`
