### PR TITLE
feat: added hook for creating onlinePlayground identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ const createDittoInstance = async (path) => {
 ## Creating Identities
 
 Ditto instances are created by providing an `Identity` object to the Ditto constructor. Identities can be of several different types,
-and can be created manually as JS objects, or using the identity hooks (`useOfflinePlaygroundIdentity`, `useOnlineIdentity`), which also makes it easier to configure authentication for your
+and can be created manually as JS objects, or using the identity hooks (`useOfflinePlaygroundIdentity`, `useOnlineIdentity`, `useOnlinePlaygroundIdentity`), which also makes it easier to configure authentication for your
 apps:
+
+### Offline Identities
 
 ```ts
 const { create } = useOfflinePlaygroundIdentity()
@@ -110,8 +112,8 @@ const createDittoInstance = (forPath: string) => {
   // Example of how to create an offline playground instance
   const dittoPlaygroundIdentity = new Ditto(
     create({
-      // If you're using the Ditto cloud this ID should be the app ID shown on your app settings page, on the portal.
-      appName: 'my-app',
+      // If you're using the Ditto cloud, this ID should be the app ID shown on your app settings page on the portal.
+      appID: uuidv4(),
       siteID: 123,
     }),
     forPath,
@@ -120,6 +122,8 @@ const createDittoInstance = (forPath: string) => {
 }
 ```
 
+### Online Identities
+
 ```ts
 const { create, getAuthenticationRequired, getTokenExpiresInSeconds } = useOnlineIdentity()
 
@@ -127,10 +131,28 @@ const createDittoInstance = (forPath: string) => {
   // Example of how to create an online instance with authentication enabled
   const dittoOnline = new Ditto(
     create({
-      // If you're using the Ditto cloud this ID should be the app ID shown on your app settings page, on the portal.
+      // If you're using the Ditto cloud, this ID should be the app ID shown on your app settings page on the portal.
       appID: uuidv4(),
       enableDittoCloudSync: true,
     }, forPath),
+    forPath,
+  )
+  return dittoOnline
+}
+```
+
+```ts
+const { create } = useOnlinePlaygroundIdentity()
+
+const createDittoInstance = (forPath: string) => {
+  // Example of how to create an online playground instance
+  const dittoOnline = new Ditto(
+    create({
+      // If you're using the Ditto cloud, this ID should be the app ID shown on your app settings page on the portal.
+      appID: uuidv4(),
+      // If you're using the Ditto cloud, this token should be the Online Playground Authentication Token shown on your app settings page on the portal. 
+      token: 'my-token'
+    }),
     forPath,
   )
   return dittoOnline
@@ -155,7 +177,7 @@ or with yarn
 yarn add @dittolive/ditto @dittolive/react-ditto
 ```
 
-2. In `./src/index.js` or if you're using typescript `./src/index.tsx` setup Ditto with the `DittoProvider` like so:
+2. In `./src/index.js`, or `./src/index.tsx` if you're using typescript, setup Ditto with the `DittoProvider` like so:
 
 ```tsx
 import { DittoProvider, useOfflinePlaygroundIdentity } from '@dittolive/react-ditto'
@@ -221,7 +243,7 @@ export default function App() {
 }
 ```
 
-Alternatively, you can also choose to go with the lazy variants of these hooks (`useLazyPendingCursorOperation` and `useLazyPendingIDSpecificOperation`), ir order to launch queries on the data store as a response to a user event:
+Alternatively, you can also choose to go with the lazy variants of these hooks (`useLazyPendingCursorOperation` and `useLazyPendingIDSpecificOperation`), in order to launch queries on the data store as a response to a user event:
 
 ```tsx
 import { usePendingCursorOperation, useMutations } from '@dittolive/react-ditto';
@@ -247,7 +269,7 @@ export default function App() {
 
 ## Working with Online apps
 
-Using the [Portal](http://portal.ditto.live) you can create apps that sync to the cloud. These apps must be created with an `onlineWithAuthentication` identity type, for which the `useOnlineIdentity` hook can be used. The `useOnlineIdentity` hook helps you create online Ditto instances that sync with the cloud, following these steps:
+Using the [Portal](http://portal.ditto.live) you can create apps that sync to the cloud. If you're just getting started with Ditto and want to experiment without authentication, you may use the `useOnlinePlaygroundIdentity` hook to create an `onlinePlayground` identity type. This **should not** be used in production environments. Otherwise, online apps must be created with an `onlineWithAuthentication` identity type, for which the `useOnlineIdentity` hook can be used. The `useOnlineIdentity` hook helps you create online Ditto instances that sync with the cloud, following these steps:
 
 ```tsx
 /** Example of a React root component setting up a single ditto instance that uses a development connection */

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -1,2 +1,3 @@
 export * from './useOfflinePlaygroundIdentity'
 export * from './useOnlineIdentity'
+export * from './useOnlinePlaygroundIdentity'

--- a/src/identity/useOfflinePlaygroundIdentity.ts
+++ b/src/identity/useOfflinePlaygroundIdentity.ts
@@ -9,11 +9,11 @@ export interface CreateOfflinePlaygroundIdentityParams {
  * @example
 
  * ```js
- *
  * const { create } = useOfflinePlaygroundIdentity();
  *
- * const myIdentity = create({appName: 'my-app', siteID: 1234});
+ * const myIdentity = create({appId: uuid(), siteID: 1234});
  * const ditto = new Ditto(myIdentity, '/path');
+ * ```
  *
  * A hook for creating Development Ditto identity objects.
  */

--- a/src/identity/useOnlineIdentity.ts
+++ b/src/identity/useOnlineIdentity.ts
@@ -31,7 +31,6 @@ export interface useOnlineIdentityProps {
  * @example
 
  * ```js
- **
  * const { create, isAuthenticationRequired, tokenExpiresInSeconds } = useOnlineIdentity();
  *
  * const onlineIdentity = create({appID: uuid(), enableDittoCloudSync: true});
@@ -41,8 +40,10 @@ export interface useOnlineIdentityProps {
  * ...
  *
  * return <button onClick={() => ditto.auth.loginWithToken('my-token', 'my-provider')}>Authenticate</button>
- *
- * A hook for creating OnlineDitto identity objects.
+ * ```
+ * 
+ * A hook for creating OnlineDitto identity objects. For creating OnlinePlayground identities, 
+ * use `{@link useOnlinePlaygroundIdentity}` instead.
  * @returns useOnlineIdentityProps
  */
 export const useOnlineIdentity = (): useOnlineIdentityProps => {

--- a/src/identity/useOnlinePlaygroundIdentity.spec.ts
+++ b/src/identity/useOnlinePlaygroundIdentity.spec.ts
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react'
+import { expect } from 'chai'
+import { v4 as uuidv4 } from 'uuid'
+
+import { useOnlinePlaygroundIdentity } from './useOnlinePlaygroundIdentity'
+
+describe('Ditto useOnlinePlaygroundIdentity hook tests', () => {
+  it('should correctly create an onlinePlayground identity', () => {
+    const appID = uuidv4()
+
+    const { result } = renderHook(() => useOnlinePlaygroundIdentity())
+
+    expect(result.current.create).to.exist
+
+    const identity = result.current.create({
+      appID: appID,
+      token: 'my-token',
+    })
+
+    expect(identity).to.eql({
+      type: 'onlinePlayground',
+      appID: appID,
+      token: 'my-token',
+      customAuthURL: undefined,
+      enableDittoCloudSync: undefined,
+    })
+  })
+})

--- a/src/identity/useOnlinePlaygroundIdentity.ts
+++ b/src/identity/useOnlinePlaygroundIdentity.ts
@@ -1,0 +1,49 @@
+import { IdentityOnlinePlayground } from '@dittolive/ditto'
+
+export interface CreateOnlinePlaygroundIdentityParams {
+  appID: string
+  token: string
+  enableDittoCloudSync?: boolean
+  customAuthURL?: string
+}
+
+export interface useOnlinePlaygroundIdentityProps {
+  /**
+   * Function used for creating a new online playground identity.
+   * */
+  create: (
+    params: CreateOnlinePlaygroundIdentityParams,
+  ) => IdentityOnlinePlayground
+}
+
+/**
+ * @example
+ * ```js
+ * const { create } = useOnlinePlaygroundIdentity();
+ *
+ * const myIdentity = create({appId: uuid(), token: 'my-token'});
+ * const ditto = new Ditto(myIdentity, '/path');
+ * ```
+ *
+ * A hook for creating OnlinePlayground Ditto identity objects.
+ * @returns useOnlinePlaygroundIdentityProps
+ */
+export const useOnlinePlaygroundIdentity =
+  (): useOnlinePlaygroundIdentityProps => {
+    return {
+      create: ({
+        appID,
+        token,
+        enableDittoCloudSync,
+        customAuthURL,
+      }: CreateOnlinePlaygroundIdentityParams): IdentityOnlinePlayground => {
+        return {
+          type: 'onlinePlayground',
+          appID,
+          token,
+          enableDittoCloudSync,
+          customAuthURL,
+        }
+      },
+    }
+  }


### PR DESCRIPTION
PR adds a new hook `useOnlinePlaygroundIdentity` for creating `onlinePlayground` identities. I opted for a separate hook mainly for three reasons:

1. Maintain the factory pattern we currently have for these hooks (i.e. all return 1 `create` function + optional utils)
2. So users of this library don't need to wrangle a return type like `IdentityOnlinePlayground | IdentityOnlineWithAuthentication`
3. Emphasize separation of `onlinePlayground` identity from `onlineWithAuthentication`, as it is not meant for production environments.

Resolves #31