### PR TITLE
feat!: upgrade `@dittolive/ditto` peer dependency to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "^2.1.0",
+    "@dittolive/ditto": "^3.0.0",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^2.1.0",
+    "@dittolive/ditto": "^3.0.0",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/src/presence/useConnectionStatus.ts
+++ b/src/presence/useConnectionStatus.ts
@@ -1,4 +1,4 @@
-import { ConnectionType, Observer, Peer } from '@dittolive/ditto'
+import { ConnectionType, Observer } from '@dittolive/ditto'
 import { useEffect, useRef, useState } from 'react'
 
 import { useDitto } from '../useDitto'
@@ -25,23 +25,18 @@ export const useConnectionStatus = (
 
   useEffect(() => {
     if (ditto) {
-      peersObserverRef.current = ditto.presence.observe(
-        ({ remotePeers }: { remotePeers: Peer[] }) => {
-          const nextActiveConnections = remotePeers.reduce(
-            (acc: Set<ConnectionType>, peer: Peer) => {
-              peer.connections.forEach((connection) => acc.add(connection.type))
+      peersObserverRef.current = ditto.presence.observe(({ remotePeers }) => {
+        const nextActiveConnections = remotePeers.reduce((acc, peer) => {
+          peer.connections.forEach((connection) => acc.add(connection.type))
 
-              return acc
-            },
-            new Set(),
-          )
-          if (Array.from(nextActiveConnections).includes(params.forTransport)) {
-            setIsConnected(true)
-          } else {
-            setIsConnected(false)
-          }
-        },
-      )
+          return acc
+        }, new Set<ConnectionType>())
+        if (Array.from(nextActiveConnections).includes(params.forTransport)) {
+          setIsConnected(true)
+        } else {
+          setIsConnected(false)
+        }
+      })
 
       return function disconnect() {
         if (peersObserverRef.current) {

--- a/src/presence/useConnectionStatus.ts
+++ b/src/presence/useConnectionStatus.ts
@@ -1,4 +1,4 @@
-import { Observer, PresenceConnectionType, RemotePeer } from '@dittolive/ditto'
+import { ConnectionType, Observer, Peer } from '@dittolive/ditto'
 import { useEffect, useRef, useState } from 'react'
 
 import { useDitto } from '../useDitto'
@@ -9,7 +9,7 @@ export interface ConnectionStatusParams {
    */
   path?: string
   /** Transport for which the connection status is retrieved. */
-  forTransport: 'WebSocket' | 'WiFi'
+  forTransport: ConnectionType
 }
 
 /** Hook used to retrieve the connection status over a given transport.
@@ -25,23 +25,23 @@ export const useConnectionStatus = (
 
   useEffect(() => {
     if (ditto) {
-      peersObserverRef.current = ditto.observePeers((peers) => {
-        const nextActiveConnections = peers.reduce(
-          (acc: Set<PresenceConnectionType>, peer: RemotePeer) => {
-            peer.connections.forEach((connectionType) =>
-              acc.add(connectionType),
-            )
+      peersObserverRef.current = ditto.presence.observe(
+        ({ remotePeers }: { remotePeers: Peer[] }) => {
+          const nextActiveConnections = remotePeers.reduce(
+            (acc: Set<ConnectionType>, peer: Peer) => {
+              peer.connections.forEach((connection) => acc.add(connection.type))
 
-            return acc
-          },
-          new Set(),
-        )
-        if (Array.from(nextActiveConnections).includes(params.forTransport)) {
-          setIsConnected(true)
-        } else {
-          setIsConnected(false)
-        }
-      })
+              return acc
+            },
+            new Set(),
+          )
+          if (Array.from(nextActiveConnections).includes(params.forTransport)) {
+            setIsConnected(true)
+          } else {
+            setIsConnected(false)
+          }
+        },
+      )
 
       return function disconnect() {
         if (peersObserverRef.current) {

--- a/src/queries/useRemotePeers.tsx
+++ b/src/queries/useRemotePeers.tsx
@@ -25,11 +25,9 @@ export function useRemotePeers(params: UsePeersParams = {}): {
   useEffect(() => {
     let observer: Observer | undefined
     if (ditto) {
-      observer = ditto.presence.observe(
-        ({ remotePeers: peers }: { remotePeers: Peer[] }) => {
-          setRemotePeers(peers)
-        },
-      )
+      observer = ditto.presence.observe(({ remotePeers: peers }) => {
+        setRemotePeers(peers)
+      })
     } else {
       setRemotePeers([])
       observer = undefined

--- a/src/queries/useRemotePeers.tsx
+++ b/src/queries/useRemotePeers.tsx
@@ -1,4 +1,4 @@
-import { Ditto, Observer, RemotePeer } from '@dittolive/ditto'
+import { Ditto, Observer, Peer } from '@dittolive/ditto'
 import { useEffect, useState } from 'react'
 
 import { useDitto } from '../useDitto'
@@ -17,17 +17,19 @@ export interface UsePeersParams {
  */
 export function useRemotePeers(params: UsePeersParams = {}): {
   ditto: Ditto
-  remotePeers: RemotePeer[]
+  remotePeers: Peer[]
 } {
   const { ditto } = useDitto(params.path)
-  const [remotePeers, setRemotePeers] = useState<RemotePeer[]>([])
+  const [remotePeers, setRemotePeers] = useState<Peer[]>([])
 
   useEffect(() => {
     let observer: Observer | undefined
     if (ditto) {
-      observer = ditto.observePeers((peers: RemotePeer[]) => {
-        setRemotePeers(peers)
-      })
+      observer = ditto.presence.observe(
+        ({ remotePeers: peers }: { remotePeers: Peer[] }) => {
+          setRemotePeers(peers)
+        },
+      )
     } else {
       setRemotePeers([])
       observer = undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,10 +905,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@dittolive/ditto@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-2.1.0.tgz#1a2ec2cf5720337110b4693b6bf935104cae6837"
-  integrity sha512-zUyWuyXXnABLCIxMkOCmaciM4TNTCeiewMyJltoQHB55yrszWT399vJJw/jBsNkqv7BrVCPeYuz7+fCPi+PIuw==
+"@dittolive/ditto@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-3.0.2.tgz#9ae1579f303d7a26e6e34d0b5c8615aabdfda6b9"
+  integrity sha512-SFYP+8HbrX9sZDc5HwI+/NoQaZb/OtqWF5KbW4n2KafCPEfa2aUErc2m94AfJRxpCwcwWrBZk1XyfrCCBJQ8QA==
   dependencies:
     cbor-redux "^0.4.0"
 


### PR DESCRIPTION
This PR upgrades the `@dittolive/ditto` peer dependency to ^3.0.0 and replaces deprecated usages of `RemotePeer`, `PresenceConnectionType` and `observePeers`.

The plan would be to release this as a breaking change, i.e., v0.10.0, and then release and alpha version from #40 as another breaking change, i.e., v0.11.0-alpha.0.