### PR TITLE
feat!: upgrade `@dittolive/ditto` peer dependency to ^4.0.0-alpha2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/getditto/react-ditto.git"
   },
   "peerDependencies": {
-    "@dittolive/ditto": "^3.0.0",
+    "@dittolive/ditto": "^4.0.0-alpha2",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
   "devDependencies": {
-    "@dittolive/ditto": "^3.0.0",
+    "@dittolive/ditto": "^4.0.0-alpha2",
     "@testing-library/react": "^13.0.1",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,10 +905,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@dittolive/ditto@^3.0.0":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-3.0.2.tgz#9ae1579f303d7a26e6e34d0b5c8615aabdfda6b9"
-  integrity sha512-SFYP+8HbrX9sZDc5HwI+/NoQaZb/OtqWF5KbW4n2KafCPEfa2aUErc2m94AfJRxpCwcwWrBZk1XyfrCCBJQ8QA==
+"@dittolive/ditto@^4.0.0-alpha2":
+  version "4.0.0-alpha2"
+  resolved "https://registry.yarnpkg.com/@dittolive/ditto/-/ditto-4.0.0-alpha2.tgz#ff74c894ea6635655911170c546deae8368c8ff7"
+  integrity sha512-81Z9ctMITz4WplyLtaoShvEo8UL1gturmCaSZ7ubZ/XURr4V67/zF754VvFCpagEAXUbo5q2FXN5z3OdeUu+eA==
   dependencies:
     cbor-redux "^0.4.0"
 


### PR DESCRIPTION
This PR upgrades the `@dittolive/ditto` peer dependency to ^4.0.0-alpha2. I plan on releasing an alpha version from this after #39 is released.