### PR TITLE
feat: add support for async setup functions

### DIFF
--- a/src/DittoProvider.tsx
+++ b/src/DittoProvider.tsx
@@ -70,11 +70,25 @@ export const DittoProvider: React.FunctionComponent<DittoProviderProps> = (
           const dittoHash: DittoHash = {}
           const dittos: Ditto[] = setupReturnValue
           for (const ditto of dittos) {
+            if (!(ditto instanceof Ditto)) {
+              throw new Error(
+                // Type is `never` because correct use never reaches this point
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                `expected an array of Ditto instances to be returned by the setup function, but at least one element is not a Ditto instance (got ${ditto})`,
+              )
+            }
             dittoHash[ditto.persistenceDirectory] = ditto
           }
           setDittoHash(dittoHash)
         } else {
           const ditto = setupReturnValue
+          if (!(ditto instanceof Ditto)) {
+            throw new Error(
+              // Type is `never` because correct use never reaches this point
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+              `expected a Ditto instance to be returned by the setup function, but got ${ditto}`,
+            )
+          }
           const dittoHash: DittoHash = {}
           dittoHash[ditto.persistenceDirectory] = ditto
           setDittoHash(dittoHash)

--- a/src/DittoProvider.tsx
+++ b/src/DittoProvider.tsx
@@ -20,7 +20,7 @@ export interface DittoProviderProps {
    *
    * Returns a single Ditto instance or an array of instances.
    */
-  setup: () => Ditto | Ditto[]
+  setup: () => Ditto | Ditto[] | Promise<Ditto | Ditto[]>
   render?: RenderFunction
   children?: RenderFunction
 }
@@ -65,7 +65,7 @@ export const DittoProvider: React.FunctionComponent<DittoProviderProps> = (
       hasMountEffectStarted.current = true
       try {
         await init(props.initOptions)
-        const setupReturnValue: Ditto | Ditto[] = props.setup()
+        const setupReturnValue: Ditto | Ditto[] = await props.setup()
         if (Array.isArray(setupReturnValue)) {
           const dittoHash: DittoHash = {}
           const dittos: Ditto[] = setupReturnValue


### PR DESCRIPTION
Async setup functions are required to correctly await `ditto.disableSyncWithV3()`.

Required for #54 

To be merged with a merge commit.