### PR TITLE
chore: update `create-react-app` example in Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.11.0](https://github.com/getditto/react-ditto/compare/v0.11.0-alpha.0...v0.11.0) (2023-03-22)
 
-### Unreleased
-
-### Changed
-
-- updated `create-react-app` example in Readme ([#59](https://github.com/getditto/react-ditto/pull/59))
-
 
 ### ⚠ BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.11.0](https://github.com/getditto/react-ditto/compare/v0.11.0-alpha.0...v0.11.0) (2023-03-22)
 
+### Unreleased
+
+### Changed
+
+- updated `create-react-app` example in Readme ([#59](https://github.com/getditto/react-ditto/pull/59))
+
 
 ### ⚠ BREAKING CHANGES
 


### PR DESCRIPTION
I tried following the example and ran into some issues. Here, I have updated the Readme to fix these. 

- add correct imports
- fix syntax
- add reference to more information on specifying a web assembly module
- convert the example to use `onlinePlayground` which is preferred
- updates React syntax
- turns the example into a basic tasks app