### PR TITLE
fix: update tar-fs to 3.0.9 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": ">=16.0.0"
   },
   "resolutions": {
-    "tar-fs": "3.0.8"
+    "tar-fs": "3.0.9"
   },
   "devDependencies": {
     "@dittolive/ditto": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,10 +6057,10 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
-tar-fs@3.0.8, tar-fs@^3.0.6:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.8.tgz#8f62012537d5ff89252d01e48690dc4ebed33ab7"
-  integrity sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==
+tar-fs@3.0.9, tar-fs@^3.0.6:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.9.tgz#d570793c6370d7078926c41fa422891566a0b617"
+  integrity sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
## Summary
• Updates tar-fs resolution from 3.0.8 to 3.0.9 to fix CVE-2025-48387
• Fixes high severity vulnerability that allows extraction outside specified directory  
• All builds and tests pass with the updated dependency

## Test plan
- [x] Build passes locally (`npm run build`)
- [x] All tests pass locally (`yarn test`)
- [x] Verified tar-fs is now at version 3.0.9
- [x] No breaking changes detected

🤖 Generated with [Claude Code](https://claude.ai/code)