### PR TITLE
SDKS-1679: Fix tar-fs security vulnerability CVE-2025-59343

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": ">=16.0.0"
   },
   "resolutions": {
-    "tar-fs": "3.0.9"
+    "tar-fs": "3.1.1"
   },
   "devDependencies": {
     "@dittolive/ditto": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,10 +6057,10 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
-tar-fs@3.0.9, tar-fs@^3.0.6:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.9.tgz#d570793c6370d7078926c41fa422891566a0b617"
-  integrity sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==
+tar-fs@3.1.1, tar-fs@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
## Summary
- Updated tar-fs from 3.0.9 to 3.1.1 to resolve CVE-2025-59343
- This fixes a symlink validation bypass vulnerability in tar-fs

## Details
The tar-fs package versions >= 3.0.0 and < 3.1.1 had a vulnerability that could allow symlink validation bypass if the destination directory is predictable with a specific tarball.

## Test plan
- [x] Run `yarn install` to update dependencies
- [x] Run `yarn audit` to verify the vulnerability is resolved
- [x] Run `yarn test` to ensure all tests pass
- [x] Run `yarn build` to verify the build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)