### PR TITLE
security: fix picomatch ReDoS vulnerability across all package-lock.json files

### DIFF
--- a/examples/vite-typescript-example/package-lock.json
+++ b/examples/vite-typescript-example/package-lock.json
@@ -8471,9 +8471,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9901,9 +9901,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7724,7 +7724,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- Upgrade `picomatch` 2.3.1 → 2.3.2 in root `package-lock.json` (ReDoS via extglob quantifiers)
- Upgrade `picomatch` 2.3.1 → 2.3.2 in `examples/vite-typescript-example/package-lock.json` (ReDoS via extglob quantifiers)
- Upgrade `picomatch` 4.0.3 → 4.0.4 in `examples/vite-typescript-example/package-lock.json` (tinyglobby transitive dep, ReDoS via extglob quantifiers)

Resolves Dependabot alerts: #246, #247, #249

## Linear Tickets

[Small Peer - Security](https://linear.app/ditto/project/small-peer-security-6b319fd5d55e)

### Closes

- [SPO-338](https://linear.app/ditto/issue/SPO-338) — picomatch ReDoS via extglob quantifiers (`package-lock.json`, dependabot #246)
- [SPO-339](https://linear.app/ditto/issue/SPO-339) — picomatch ReDoS via extglob quantifiers (`examples/vite-typescript-example/package-lock.json`, dependabot #247)
- [SPO-340](https://linear.app/ditto/issue/SPO-340) — picomatch ReDoS via extglob quantifiers (`examples/vite-typescript-example/package-lock.json`, dependabot #249)

## Test plan

- [ ] `npm audit` in root no longer reports picomatch vulnerabilities
- [ ] `npm audit` in `examples/vite-typescript-example` no longer reports picomatch vulnerabilities
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)