### PR TITLE
Add CODEOWNERS for repo ownership clarity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @getditto/sdk-js-engineers @skylerjokiel


### PR DESCRIPTION
Adds a CODEOWNERS file assigning @getditto/sdk-js-engineers and @skylerjokiel as default owners to make it clear that the SDKs team owns this repo.