### PR TITLE
Fix security vulnerabilities (npm)

### DIFF
--- a/examples/vite-typescript-example/package-lock.json
+++ b/examples/vite-typescript-example/package-lock.json
@@ -7895,9 +7895,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,9 +3132,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Batched Dependabot upgrades for high-severity vulnerabilities.

### Alerts fixed

- **basic-ftp** 5.2.0 → 5.3.0 (transitive via `get-uri` → `pac-proxy-agent` → `puppeteer`) — `package-lock.json`
  - [GHSA-chqc-8p9q-pq6q](https://github.com/advisories/GHSA-chqc-8p9q-pq6q) / CVE-2026-39983 — FTP Command Injection via CRLF (alert #261, SPO-498)
  - [GHSA-6v7q-wjvx-w8wg](https://github.com/advisories/GHSA-6v7q-wjvx-w8wg) — Incomplete CRLF protection allows arbitrary FTP commands via credentials/MKD (alert #263, SPO-503)
  - [GHSA-rp42-5vxx-qpwr](https://github.com/advisories/GHSA-rp42-5vxx-qpwr) — DoS via unbounded memory consumption in `Client.list()` (alert #265, SPO-633)
- **lodash** 4.17.23 → 4.18.1 (transitive via `karma`, `karma-typescript`, `vue-eslint-parser`) — `examples/vite-typescript-example/package-lock.json`
  - [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) / CVE-2026-4800 — Code Injection via `_.template` imports key names (alert #256, SPO-464)

Target versions are sourced from Linear / Dependabot and may not reflect the latest suitable release — verify resolved lockfile versions. `lodash` was bumped to 4.18.1 (current latest in the 4.x line; satisfies the `>=4.18.0` fix requirement).

### Verification

- `npm install` succeeds in the root and in `examples/vite-typescript-example`.
- `npm audit --json` reports no remaining advisories for `basic-ftp` (root) or `lodash` (vite example).
- `npm run build` succeeds in both workspaces.

## Test plan

- [ ] CI passes
- [ ] No new high/critical vulnerabilities in affected lockfiles
- [ ] Affected SDK/component builds successfully

Resolves: SPO-633, SPO-503, SPO-498, SPO-464
