### PR TITLE
SPO-912: Fix copilot reviewer default and rename job ID in react-ditto security workflow

### DIFF
--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -26,7 +26,7 @@ on:
         description: "Comma-separated GitHub teams/users to request review from"
         required: false
         type: string
-        default: "security-team,copilot"
+        default: "security-team"
 
 permissions:
   contents: write


### PR DESCRIPTION
## SPO-912: Fix copilot reviewer default and rename job ID in react-ditto security workflow

[SPO-912](https://linear.app/ditto/issue/SPO-912/fix-copilot-reviewer-default-and-rename-job-id-in-react-ditto-security)