### PR TITLE
ci: pass target_branch through security-update caller workflow

### DIFF
--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: "security-team"
+      target_branch:
+        description: 'Target branch for checkout and PR base (default: dispatch ref)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -41,6 +45,7 @@ jobs:
       linear_tickets: ${{ inputs.linear_tickets }}
       batch_id: ${{ inputs.batch_id }}
       reviewers: ${{ inputs.reviewers }}
+      target_branch: ${{ inputs.target_branch }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GH_TOKEN_SECURITY_PATCHES: ${{ secrets.GH_TOKEN_SECURITY_PATCHES }}


### PR DESCRIPTION
## Summary

- Add `target_branch` dispatch input to the security-update caller workflow
- Pass it through to the reusable workflow in sec-tools-public
- Enables security update PRs to target release branches instead of always defaulting to main

Closes SPO-980

## Test plan

- [ ] Workflow dispatch still works without `target_branch` (backwards compatible)
- [ ] Workflow dispatch with `target_branch` creates PR against the specified branch

## AI assistance

- [x] AI-assisted (Claude Code)
  - **Supervision:** Active
  - **AI-generated:** Workflow input + passthrough
  - **Human-verified:** Reviewed diff