### PR TITLE
Add a files allowlist to the published package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.1](https://github.com/getditto/react-ditto/compare/v1.0.0...v1.0.1)
+
+### Bug Fixes
+
+* Add a `files` allowlist so the published package only includes what is needed:
+  the built `dist` output (including source maps for debuggable stacks, with test
+  files excluded) plus the README and CHANGELOG.
+
 ## [1.0.0](https://github.com/getditto/react-ditto/compare/v0.11.2...v1.0.0)
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@dittolive/react-ditto",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React wrappers for Ditto",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "files": [
+    "dist",
+    "!dist/**/*.spec.*",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",


### PR DESCRIPTION
Only ship what is needed: the built dist output (minus test files) plus the README and CHANGELOG