### PR TITLE
FORGE-2185: react-ditto v5 migration follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,29 @@ export default function App() {
 }
 ```
 
+### Subscriptions under Ditto v5
+
+Ditto v5 enables `DQL_RESTRICT_SUBSCRIPTION` by default, so a sync subscription
+whose query contains `ORDER BY`, `LIMIT`, or `OFFSET` is rejected
+("Unsupported feature: Limit or Order by"). Because `useQuery` observes and
+subscribes with the same query, an observed query carrying those clauses will
+fail to register a subscription.
+
+When that happens the store observer still works and keeps returning local data,
+and the failure is reported through `onError` (it does **not** populate the
+hook's `error`, which is reserved for query/observer failures). To keep sync
+working, pass a `subscriptionQuery` without the restricted clauses:
+
+```tsx
+const { items } = useQuery<Task>('SELECT * FROM tasks ORDER BY createdAt LIMIT 20', {
+  // Observe the ordered/limited result set, but subscribe to the full set.
+  subscriptionQuery: 'SELECT * FROM tasks',
+})
+```
+
+`subscriptionQuery` is ignored when `localOnly` is `true` (no subscription is
+created).
+
 ## Mutating and on-demand queries with `useExecuteQuery`
 
 `useExecuteQuery` returns an execution function that runs a DQL query on demand.
@@ -221,6 +244,42 @@ export default function AddTask() {
 Query arguments can be supplied when setting up the hook and/or when calling the
 execution function; when both are provided they are shallow-merged, with the
 execution function's arguments taking precedence.
+
+## Presence
+
+Two hooks expose Ditto's presence information so you can react to the peers and
+transports currently connected.
+
+`useRemotePeers` returns the list of connected remote peers, updating as peers
+join and leave:
+
+```tsx
+import { useRemotePeers } from '@dittolive/react-ditto'
+
+export default function PeerCount() {
+  const { remotePeers } = useRemotePeers()
+
+  return <p>{remotePeers.length} peer(s) connected</p>
+}
+```
+
+`useConnectionStatus` returns a boolean for whether a connection is active over
+a given transport. Pass the transport via `forTransport` (a `ConnectionType`:
+`'Bluetooth'`, `'P2PWiFi'`, `'AccessPoint'`, or `'WebSocket'`):
+
+```tsx
+import { useConnectionStatus } from '@dittolive/react-ditto'
+
+export default function BluetoothIndicator() {
+  const isConnected = useConnectionStatus({ forTransport: 'Bluetooth' })
+
+  return <p>Bluetooth: {isConnected ? 'connected' : 'disconnected'}</p>
+}
+```
+
+Both hooks accept an optional `path` to target a specific Ditto instance when
+several are registered with the `DittoProvider`; omit it to use the first
+registered instance.
 
 ## Quick Start with `vite`
 

--- a/src/DittoLazyProvider.spec.tsx
+++ b/src/DittoLazyProvider.spec.tsx
@@ -96,40 +96,6 @@ describe('Ditto Lazy Provider Tests', () => {
     )
   })
 
-  it('should fail to load ditto from web assembly file that does not exist', async function () {
-    const config = testConfig()
-    const initOptions = {
-      webAssemblyModule:
-        '/base/node_modules/@dittolive/ditto/web/ditto-that-does-not-exist.wasm',
-    }
-
-    root.render(
-      <DittoLazyProvider
-        initOptions={initOptions}
-        setup={() => openOfflineDitto(config.databaseID, config.path)}
-      >
-        {({ loading, error }) => {
-          return (
-            <>
-              <div data-testid="loading">{`${loading}`}</div>
-              <div data-testid="error">{error?.message}</div>
-            </>
-          )
-        }}
-      </DittoLazyProvider>,
-    )
-
-    await waitFor(
-      () =>
-        container.querySelector("div[data-testid='loading']").innerHTML ===
-        'false',
-    )
-    await waitFor(
-      () =>
-        container.querySelector("div[data-testid='error']").innerHTML === '',
-    )
-  })
-
   it('should mount the provider with an empty set of Ditto instances.', async () => {
     const config = testConfig()
 

--- a/src/DittoProvider.spec.tsx
+++ b/src/DittoProvider.spec.tsx
@@ -97,41 +97,6 @@ describe('Ditto Provider Tests', () => {
     )
   })
 
-  it('should fail to load ditto from web assembly file that does not exist', async function () {
-    const config = testConfig()
-
-    const initOptions = {
-      webAssemblyModule:
-        '/base/node_modules/@dittolive/ditto/web/ditto-that-does-not-exist.wasm',
-    }
-
-    root.render(
-      <DittoProvider
-        initOptions={initOptions}
-        setup={() => openOfflineDitto(config.databaseID, config.path)}
-      >
-        {({ loading, error }) => {
-          return (
-            <>
-              <div data-testid="loading">{`${loading}`}</div>
-              <div data-testid="error">{error?.message}</div>
-            </>
-          )
-        }}
-      </DittoProvider>,
-    )
-
-    await waitFor(
-      () =>
-        container.querySelector("div[data-testid='loading']").innerHTML ===
-        'false',
-    )
-    await waitFor(
-      () =>
-        container.querySelector("div[data-testid='error']").innerHTML === '',
-    )
-  })
-
   it('should mount the provider with the initialized Ditto instance.', async () => {
     const config = testConfig()
 

--- a/src/queries/useQuery.spec.tsx
+++ b/src/queries/useQuery.spec.tsx
@@ -210,11 +210,9 @@ describe('useQuery', function () {
       timeout: 5000,
     })
 
-    // The observer succeeded and is serving data...
     expect(result.current.items).to.have.lengthOf(3)
-    // ...so the rejected subscription must not have set the error state.
+    // A rejected subscription must not set the hook error state.
     expect(result.current.error).to.be.null
-    // The subscription itself failed to register.
     expect(result.current.syncSubscription).to.be.undefined
   })
 
@@ -237,9 +235,40 @@ describe('useQuery', function () {
     })
 
     expect(result.current.items).to.have.lengthOf(3)
-    // The unrestricted subscriptionQuery registers cleanly, no error.
     expect(result.current.error).to.be.null
     expect(result.current.syncSubscription).to.exist
+  })
+
+  it('clears a stale subscription when a reset re-registers with a rejected query', async () => {
+    const config = testConfig()
+
+    const { result, rerender } = renderHook(
+      ({ query }: { query: string }) =>
+        useQuery(query, {
+          persistenceDirectory: config.persistenceDirectory,
+          // Swallow the expected subscription failure after the query change.
+          onError: () => {},
+        }),
+      {
+        initialProps: { query: 'select * from foo' },
+        wrapper: wrapper(config.databaseID, config.persistenceDirectory),
+      },
+    )
+
+    await waitFor(() => expect(result.current.syncSubscription).to.exist, {
+      timeout: 5000,
+    })
+
+    // Changing to a query rejected by registerSubscription (ORDER BY/LIMIT
+    // under v5) triggers a reset. The now-cancelled subscription must not
+    // linger on the return value.
+    rerender({ query: 'select * from foo order by document limit 3' })
+
+    await waitFor(() => expect(result.current.items).to.have.lengthOf(3), {
+      timeout: 5000,
+    })
+    expect(result.current.syncSubscription).to.be.undefined
+    expect(result.current.error).to.be.null
   })
 
   it('has the expected failure mode when used with a mutating query', async () => {

--- a/src/queries/useQuery.spec.tsx
+++ b/src/queries/useQuery.spec.tsx
@@ -189,6 +189,59 @@ describe('useQuery', function () {
     await waitFor(() => expect(result.current.error).to.exist)
   })
 
+  it('keeps a working observer when the subscription query is rejected under v5', async () => {
+    const config = testConfig()
+
+    const { result } = renderHook(
+      () =>
+        // `ORDER BY`/`LIMIT` are valid to observe but rejected by
+        // `registerSubscription` under v5's `DQL_RESTRICT_SUBSCRIPTION`.
+        useQuery('select * from foo order by document limit 3', {
+          persistenceDirectory: config.persistenceDirectory,
+          // Swallow the expected subscription failure so it is not logged.
+          onError: () => {},
+        }),
+      {
+        wrapper: wrapper(config.databaseID, config.persistenceDirectory),
+      },
+    )
+
+    await waitFor(() => expect(result.current.items).not.to.be.empty, {
+      timeout: 5000,
+    })
+
+    // The observer succeeded and is serving data...
+    expect(result.current.items).to.have.lengthOf(3)
+    // ...so the rejected subscription must not have set the error state.
+    expect(result.current.error).to.be.null
+    // The subscription itself failed to register.
+    expect(result.current.syncSubscription).to.be.undefined
+  })
+
+  it('registers the subscription with subscriptionQuery when provided', async () => {
+    const config = testConfig()
+
+    const { result } = renderHook(
+      () =>
+        useQuery('select * from foo order by document limit 3', {
+          persistenceDirectory: config.persistenceDirectory,
+          subscriptionQuery: 'select * from foo',
+        }),
+      {
+        wrapper: wrapper(config.databaseID, config.persistenceDirectory),
+      },
+    )
+
+    await waitFor(() => expect(result.current.items).not.to.be.empty, {
+      timeout: 5000,
+    })
+
+    expect(result.current.items).to.have.lengthOf(3)
+    // The unrestricted subscriptionQuery registers cleanly, no error.
+    expect(result.current.error).to.be.null
+    expect(result.current.syncSubscription).to.exist
+  })
+
   it('has the expected failure mode when used with a mutating query', async () => {
     const config = testConfig()
 

--- a/src/queries/useQuery.ts
+++ b/src/queries/useQuery.ts
@@ -168,9 +168,12 @@ export function useQuery<
 
       storeObserverRef.current?.cancel()
       syncSubscriptionRef.current?.cancel()
+      // Clear the refs before re-registering so a failed (or skipped)
+      // registration leaves them `undefined` rather than exposing a stale,
+      // already-cancelled observer/subscription.
+      storeObserverRef.current = undefined
+      syncSubscriptionRef.current = undefined
 
-      // The observer drives `items`/`error`, so its failure becomes the hook's
-      // error state.
       try {
         storeObserverRef.current = ditto.store.registerObserver<T>(
           query,

--- a/src/queries/useQuery.ts
+++ b/src/queries/useQuery.ts
@@ -34,6 +34,19 @@ export interface UseQueryParams<
    */
   localOnly?: boolean
   /**
+   * The query used for the {@link SyncSubscription} instead of the observed
+   * `query`. Use this to pass a sync-appropriate query when the observed query
+   * carries clauses that Ditto rejects in subscriptions.
+   *
+   * Ditto v5 enables `DQL_RESTRICT_SUBSCRIPTION` by default, so a subscription
+   * query containing `ORDER BY`, `LIMIT`, or `OFFSET` throws
+   * ("Unsupported feature: Limit or Order by"). When your `query` needs those
+   * clauses for observation, pass an unrestricted `subscriptionQuery` here so
+   * sync still registers. Ignored when {@link UseQueryParams.localOnly} is
+   * `true`.
+   */
+  subscriptionQuery?: string
+  /**
    * A callback to run when an error occurs.
    *
    * @param error
@@ -170,11 +183,16 @@ export function useQuery<
       if (!params?.localOnly) {
         try {
           syncSubscriptionRef.current = ditto.sync.registerSubscription(
-            query,
+            params?.subscriptionQuery ?? query,
             params?.queryArguments,
           )
         } catch (e: unknown) {
-          setError(e)
+          // A failed subscription registration must not overwrite `error`: the
+          // observer may have succeeded and be serving data, and under v5's
+          // `DQL_RESTRICT_SUBSCRIPTION` an observed query with
+          // `ORDER BY`/`LIMIT`/`OFFSET` throws here even though observation is
+          // fine. Surface it via `onError` instead of the shared error state,
+          // and let callers pass `subscriptionQuery` to avoid it.
           if (params?.onError) params.onError(e)
           else console.error(e)
         }
@@ -191,7 +209,13 @@ export function useQuery<
     // dependency but ensures that the hook is reset when deep changes occur in
     // `queryArguments`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ditto, queryArgumentsVersion, query, params?.localOnly])
+  }, [
+    ditto,
+    queryArgumentsVersion,
+    query,
+    params?.localOnly,
+    params?.subscriptionQuery,
+  ])
 
   useEffect(() => {
     reset().then(() => setIsLoading(false))

--- a/src/queries/useQuery.ts
+++ b/src/queries/useQuery.ts
@@ -74,10 +74,12 @@ export interface UseQueryReturn<T> {
    */
   ditto: Ditto | null
   /**
-   * The most recent error that occurred while setting up the query.
+   * The most recent error from setting up the store observer.
    *
-   * Use the {@link UseQueryParams.onError | `onError`} callback parameter
-   * to handle errors as they occur.
+   * A failed sync subscription registration is not reflected here (the observer
+   * may still be serving data); those are delivered only through
+   * {@link UseQueryParams.onError | `onError`}. Use `onError` to handle all
+   * errors as they occur.
    */
   error: unknown
   /**
@@ -153,6 +155,11 @@ export function useQuery<
   const queryArgumentsVersion = useVersion(params?.queryArguments)
 
   const reset = useCallback(async () => {
+    const reportError = (e: unknown) => {
+      if (params?.onError) params.onError(e)
+      else console.error(e)
+    }
+
     const configureQuery = (onCompletion: () => void) => {
       if (!ditto) {
         onCompletion()
@@ -162,6 +169,8 @@ export function useQuery<
       storeObserverRef.current?.cancel()
       syncSubscriptionRef.current?.cancel()
 
+      // The observer drives `items`/`error`, so its failure becomes the hook's
+      // error state.
       try {
         storeObserverRef.current = ditto.store.registerObserver<T>(
           query,
@@ -173,13 +182,16 @@ export function useQuery<
         )
       } catch (e: unknown) {
         setError(e)
-        if (params?.onError) params.onError(e)
-        else console.error(e)
+        reportError(e)
         // Resolve even on failure so callers awaiting the returned promise (and
         // the loading state) are not left hanging.
         onCompletion()
       }
 
+      // Sync is best-effort: a failed subscription must not overwrite `error`,
+      // since the observer above may be serving data. Under v5's
+      // `DQL_RESTRICT_SUBSCRIPTION` an observed query with `ORDER BY`/`LIMIT`/
+      // `OFFSET` throws here; callers can pass `subscriptionQuery` to avoid it.
       if (!params?.localOnly) {
         try {
           syncSubscriptionRef.current = ditto.sync.registerSubscription(
@@ -187,14 +199,7 @@ export function useQuery<
             params?.queryArguments,
           )
         } catch (e: unknown) {
-          // A failed subscription registration must not overwrite `error`: the
-          // observer may have succeeded and be serving data, and under v5's
-          // `DQL_RESTRICT_SUBSCRIPTION` an observed query with
-          // `ORDER BY`/`LIMIT`/`OFFSET` throws here even though observation is
-          // fine. Surface it via `onError` instead of the shared error state,
-          // and let callers pass `subscriptionQuery` to avoid it.
-          if (params?.onError) params.onError(e)
-          else console.error(e)
+          reportError(e)
         }
       }
     }


### PR DESCRIPTION
Follow-ups from the [FORGE-1921](https://linear.app/ditto/issue/FORGE-1921) v5 migration review. [FORGE-2185](https://linear.app/ditto/issue/FORGE-2185)

### `useQuery` subscriptions under v5
v5 enables `DQL_RESTRICT_SUBSCRIPTION`, so `registerSubscription` rejects `ORDER BY`/`LIMIT`/`OFFSET`. Since `useQuery` subscribed with the same query it observed, such a query left the hook in an error state with no subscription while the observer kept returning local-only data.

- Added an optional `subscriptionQuery` param so callers can subscribe with a sync-appropriate query (ignored when `localOnly`).
- A failed subscription no longer overwrites `error`; it surfaces via `onError`/`console.error` instead, so a healthy observer isn't masked.

### Removed the "fails to load wasm" provider tests
Both asserted the error element was *empty*, so they passed trivially. `init()` in v5 is a process-global singleton, so a bad wasm path is never exercised after the first init and can't be tested here. The provider's error-surfacing is already covered by the setup-failure tests, so these were removed rather than rewritten.

### README
Documented the `useRemotePeers`/`useConnectionStatus` presence hooks and the v5 subscription constraint