### PR TITLE
Fix npm security vulnerabilities

### DIFF
--- a/examples/vite-typescript-example/package-lock.json
+++ b/examples/vite-typescript-example/package-lock.json
@@ -2290,9 +2290,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/vite-typescript-example/package.json
+++ b/examples/vite-typescript-example/package.json
@@ -63,7 +63,8 @@
     },
     "ws": "8.21.0",
     "form-data": "4.0.6",
-    "vite": "$vite"
+    "vite": "$vite",
+    "brace-expansion@^5.0.2": "5.0.7"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2275,11 +2275,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/cors": {
       "version": "2.8.17",
       "dev": true,
@@ -2385,6 +2380,16 @@
       "version": "9.0.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -4276,20 +4281,22 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.2",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
+      "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "ws": "~8.18.3"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -4301,6 +4308,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/ent": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "basic-ftp": "5.3.1",
     "tmp": "^0.2.7",
-    "ws": "8.21.0"
+    "ws": "8.21.0",
+    "engine.io": "6.6.7"
   },
   "devDependencies": {
     "@dittolive/ditto": "^5.0.0",


### PR DESCRIPTION
## Summary

- **engine.io** → 6.6.7 (CVE-2026-59725)
- **brace-expansion** → 5.0.7 (CVE-2026-13149)



Refs: SPO-1151

[Workflow run](https://github.com/getditto/react-ditto/actions/runs/30546548685)

> **Note:** Target versions are sourced from Tines and may not always
> reflect the latest or most appropriate release (e.g. a version may
> be deprecated upstream). Please verify that the resolved versions
> in lockfiles are suitable.

## Test plan

- [ ] CI passes
- [ ] No new high/critical vulnerabilities in affected lockfiles
- [ ] Affected SDK/component builds successfully

Generated by Tines + Claude Code